### PR TITLE
Add tab bar with basic views

### DIFF
--- a/Starter/Starter/AccountView.swift
+++ b/Starter/Starter/AccountView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct AccountView: View {
+    var body: some View {
+        Text("Account")
+            .font(.largeTitle)
+    }
+}
+
+#Preview {
+    AccountView()
+}

--- a/Starter/Starter/ChatView.swift
+++ b/Starter/Starter/ChatView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct ChatView: View {
+    var body: some View {
+        Text("Chat")
+            .font(.largeTitle)
+    }
+}
+
+#Preview {
+    ChatView()
+}

--- a/Starter/Starter/ContentView.swift
+++ b/Starter/Starter/ContentView.swift
@@ -8,7 +8,7 @@ struct ContentView: View {
 
     var body: some View {
         if loggedIn {
-            WelcomeView(username: username)
+            MainTabView(username: username)
         } else {
             loginForm
         }

--- a/Starter/Starter/ListingsView.swift
+++ b/Starter/Starter/ListingsView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct ListingsView: View {
+    var body: some View {
+        Text("Listings")
+            .font(.largeTitle)
+    }
+}
+
+#Preview {
+    ListingsView()
+}

--- a/Starter/Starter/MainTabView.swift
+++ b/Starter/Starter/MainTabView.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+struct MainTabView: View {
+    let username: String
+
+    var body: some View {
+        TabView {
+            WelcomeView(username: username)
+                .tabItem {
+                    Label("Home", systemImage: "house")
+                }
+
+            ChatView()
+                .tabItem {
+                    Label("Chat", systemImage: "bubble.right")
+                }
+
+            PostView()
+                .tabItem {
+                    Label("Post", systemImage: "plus.app")
+                }
+
+            ListingsView()
+                .tabItem {
+                    Label("Listings", systemImage: "list.bullet")
+                }
+
+            AccountView()
+                .tabItem {
+                    Label("Account", systemImage: "person")
+                }
+        }
+    }
+}
+
+#Preview {
+    MainTabView(username: "User")
+}

--- a/Starter/Starter/PostView.swift
+++ b/Starter/Starter/PostView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct PostView: View {
+    var body: some View {
+        Text("Post")
+            .font(.largeTitle)
+    }
+}
+
+#Preview {
+    PostView()
+}


### PR DESCRIPTION
## Summary
- swap Welcome screen for new `MainTabView` after login
- implement `MainTabView` containing five tabs
- add placeholder views for Chat, Post, Listings and Account

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683a4422412083289b2c1bdc0c4323c4