### PR TITLE
Add tools list to home page

### DIFF
--- a/Starter/Starter/Network.swift
+++ b/Starter/Starter/Network.swift
@@ -16,6 +16,14 @@ struct User: Codable {
     let username: String
 }
 
+struct Tool: Codable, Identifiable {
+    let id: Int
+    let name: String
+    let price: Double
+    let description: String
+    let owner_id: Int
+}
+
 func signup(username: String, password: String) {
     guard let url = URL(string: "http://localhost:3000/signup") else { return }
     var request = URLRequest(url: url)
@@ -61,6 +69,25 @@ func fetchUsers() {
         if let data = data,
            let users = try? JSONDecoder().decode([User].self, from: data) {
             print("Fetched users: \(users)")
+        }
+    }.resume()
+}
+
+func fetchTools(completion: @escaping ([Tool]) -> Void) {
+    guard let url = URL(string: "http://localhost:3000/tools") else {
+        completion([])
+        return
+    }
+
+    var request = URLRequest(url: url)
+    request.httpMethod = "GET"
+
+    URLSession.shared.dataTask(with: request) { data, _, _ in
+        if let data = data,
+           let tools = try? JSONDecoder().decode([Tool].self, from: data) {
+            completion(tools)
+        } else {
+            completion([])
         }
     }.resume()
 }

--- a/Starter/Starter/WelcomeView.swift
+++ b/Starter/Starter/WelcomeView.swift
@@ -2,15 +2,30 @@ import SwiftUI
 
 struct WelcomeView: View {
     let username: String
+    @State private var tools: [Tool] = []
 
     var body: some View {
-        VStack {
-            Spacer()
+        VStack(alignment: .leading) {
             Text("Welcome, \(username)!")
                 .font(.largeTitle)
                 .bold()
                 .padding()
-            Spacer()
+
+            List(tools) { tool in
+                VStack(alignment: .leading) {
+                    Text(tool.name)
+                        .font(.headline)
+                    Text(tool.description)
+                        .font(.subheadline)
+                }
+            }
+        }
+        .onAppear {
+            fetchTools { fetched in
+                DispatchQueue.main.async {
+                    self.tools = fetched
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- display `Tool` data on home screen
- include `Tool` model and API fetch call

## Testing
- `swift test` *(fails: `Could not find Package.swift`)*

------
https://chatgpt.com/codex/tasks/task_b_683a51ba079c8328bb403898960c2409