### PR TITLE
Add tool detail navigation

### DIFF
--- a/Starter/Starter/ToolDetailView.swift
+++ b/Starter/Starter/ToolDetailView.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+struct ToolDetailView: View {
+    let tool: Tool
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text(tool.name)
+                    .font(.largeTitle)
+                    .bold()
+                Text(tool.description ?? "No description available")
+                Text("Price: \(tool.price)")
+                if let owner = tool.owner_id {
+                    Text("Owner ID: \(owner)")
+                }
+                Spacer()
+            }
+            .padding()
+        }
+        .navigationTitle(tool.name)
+    }
+}
+
+#Preview {
+    ToolDetailView(tool: Tool(id: 1, name: "Hammer", price: "$10", description: "A sturdy hammer.", owner_id: 1))
+}

--- a/Starter/Starter/WelcomeView.swift
+++ b/Starter/Starter/WelcomeView.swift
@@ -5,18 +5,22 @@ struct WelcomeView: View {
     @State private var tools: [Tool] = []
 
     var body: some View {
-        VStack(alignment: .leading) {
-            Text("Welcome, \(username)!")
-                .font(.largeTitle)
-                .bold()
-                .padding()
+        NavigationStack {
+            VStack(alignment: .leading) {
+                Text("Welcome, \(username)!")
+                    .font(.largeTitle)
+                    .bold()
+                    .padding()
 
-            List(tools) { tool in
-                VStack(alignment: .leading) {
-                    Text(tool.name)
-                        .font(.headline)
-                    Text(tool.description ?? "No description available")
-                        .font(.subheadline)
+                List(tools) { tool in
+                    NavigationLink(destination: ToolDetailView(tool: tool)) {
+                        VStack(alignment: .leading) {
+                            Text(tool.name)
+                                .font(.headline)
+                            Text(tool.description ?? "No description available")
+                                .font(.subheadline)
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- show tools in a navigation stack
- add `ToolDetailView` to display details about a selected tool

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_683a6234df9c83288b6028725d87a5d9