### PR TITLE
Show logged in user on account page

### DIFF
--- a/Starter/Starter/AccountView.swift
+++ b/Starter/Starter/AccountView.swift
@@ -1,12 +1,39 @@
 import SwiftUI
 
 struct AccountView: View {
+    let username: String
+    @State private var user: User?
+
     var body: some View {
-        Text("Account")
-            .font(.largeTitle)
+        VStack(spacing: 20) {
+            Text("Account Details")
+                .font(.largeTitle)
+
+            if let user = user {
+                Text("Username: \(user.username)")
+                    .font(.title2)
+                Text("User ID: \(user.id)")
+                    .font(.title3)
+            } else {
+                Text("Username: \(username)")
+                    .font(.title2)
+                Text("Loading user info...")
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding()
+        .onAppear {
+            fetchUsers { users in
+                if let match = users.first(where: { $0.username == username }) {
+                    DispatchQueue.main.async {
+                        self.user = match
+                    }
+                }
+            }
+        }
     }
 }
 
 #Preview {
-    AccountView()
+    AccountView(username: "User")
 }

--- a/Starter/Starter/MainTabView.swift
+++ b/Starter/Starter/MainTabView.swift
@@ -25,7 +25,7 @@ struct MainTabView: View {
                     Label("Listings", systemImage: "list.bullet")
                 }
 
-            AccountView()
+            AccountView(username: username)
                 .tabItem {
                     Label("Account", systemImage: "person")
                 }

--- a/Starter/Starter/Network.swift
+++ b/Starter/Starter/Network.swift
@@ -57,9 +57,12 @@ func login(username: String, password: String, completion: @escaping (Bool) -> V
     }.resume()
 }
 
-func fetchUsers() {
+func fetchUsers(completion: @escaping ([User]) -> Void) {
     guard let token = UserDefaults.standard.string(forKey: "authToken"),
-          let url = URL(string: "https://6547-76-106-54-237.ngrok-free.app/users") else { return }
+          let url = URL(string: "https://6547-76-106-54-237.ngrok-free.app/users") else {
+        completion([])
+        return
+    }
 
     var request = URLRequest(url: url)
     request.httpMethod = "GET"
@@ -68,7 +71,10 @@ func fetchUsers() {
     URLSession.shared.dataTask(with: request) { data, _, _ in
         if let data = data,
            let users = try? JSONDecoder().decode([User].self, from: data) {
+            completion(users)
             print("Fetched users: \(users)")
+        } else {
+            completion([])
         }
     }.resume()
 }


### PR DESCRIPTION
## Summary
- fetch users from API with a completion handler
- pass username into `AccountView`
- load user details and display username and ID in `AccountView`
- plumb username through `MainTabView` to `AccountView`

## Testing
- `swiftc -parse Starter/Starter/AccountView.swift`
- `swiftc -parse Starter/Starter/Network.swift`
- `swiftc -parse Starter/Starter/MainTabView.swift`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_683a624741488328b5c4bd9013665146