### PR TITLE
Enhance account view with additional user info

### DIFF
--- a/Starter/Starter/AccountView.swift
+++ b/Starter/Starter/AccountView.swift
@@ -5,23 +5,64 @@ struct AccountView: View {
     @State private var user: User?
 
     var body: some View {
-        VStack(spacing: 20) {
-            Text("Account Details")
-                .font(.largeTitle)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Account Details")
+                    .font(.largeTitle)
+                    .padding(.bottom, 8)
 
-            if let user = user {
-                Text("Username: \(user.username)")
-                    .font(.title2)
-                Text("User ID: \(user.id)")
-                    .font(.title3)
-            } else {
-                Text("Username: \(username)")
-                    .font(.title2)
-                Text("Loading user info...")
-                    .foregroundColor(.secondary)
+                if let user = user {
+                    Group {
+                        Text("Username: \(user.username)")
+                            .font(.title2)
+                        Text("User ID: \(user.id)")
+                            .font(.title3)
+                        if let firstName = user.first_name {
+                            Text("First Name: \(firstName)")
+                        }
+                        if let lastName = user.last_name {
+                            Text("Last Name: \(lastName)")
+                        }
+                        if let email = user.email {
+                            Text("Email: \(email)")
+                        }
+                        if let phone = user.phone {
+                            Text("Phone: \(phone)")
+                        }
+                        if let address = user.address {
+                            Text("Address: \(address)")
+                        }
+                        if let city = user.city {
+                            Text("City: \(city)")
+                        }
+                        if let state = user.state {
+                            Text("State: \(state)")
+                        }
+                        if let zip = user.zip {
+                            Text("ZIP: \(zip)")
+                        }
+                        if let isSeller = user.is_seller {
+                            Text("Seller: \(isSeller ? "Yes" : "No")")
+                        }
+                        if let isAdmin = user.is_admin {
+                            Text("Admin: \(isAdmin ? "Yes" : "No")")
+                        }
+                        if let created = user.created_at {
+                            Text("Created: \(created)")
+                        }
+                        if let updated = user.updated_at {
+                            Text("Updated: \(updated)")
+                        }
+                    }
+                } else {
+                    Text("Username: \(username)")
+                        .font(.title2)
+                    Text("Loading user info...")
+                        .foregroundColor(.secondary)
+                }
             }
+            .padding()
         }
-        .padding()
         .onAppear {
             fetchUsers { users in
                 if let match = users.first(where: { $0.username == username }) {

--- a/Starter/Starter/Network.swift
+++ b/Starter/Starter/Network.swift
@@ -14,6 +14,18 @@ struct AuthResponse: Codable {
 struct User: Codable {
     let id: Int
     let username: String
+    let email: String?
+    let created_at: String?
+    let updated_at: String?
+    let is_seller: Bool?
+    let is_admin: Bool?
+    let first_name: String?
+    let last_name: String?
+    let phone: String?
+    let address: String?
+    let city: String?
+    let state: String?
+    let zip: String?
 }
 
 struct Tool: Codable, Identifiable {


### PR DESCRIPTION
## Summary
- extend `User` model to capture all available database fields
- show user details such as email, address and more within `AccountView`

## Testing
- `swiftc -parse -Xfrontend -disable-availability-checking Starter/Starter/*.swift`

------
https://chatgpt.com/codex/tasks/task_b_683a787552348328bec049e0a02d5a28