### PR TITLE
Add map view to home tab

### DIFF
--- a/Starter/Starter/MapView.swift
+++ b/Starter/Starter/MapView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+import MapKit
+
+struct MapView: View {
+    @State private var region = MKCoordinateRegion(
+        center: CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194),
+        span: MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
+    )
+
+    var body: some View {
+        Map(coordinateRegion: $region)
+            .edgesIgnoringSafeArea(.all)
+    }
+}
+
+#Preview {
+    MapView()
+}

--- a/Starter/Starter/WelcomeView.swift
+++ b/Starter/Starter/WelcomeView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct WelcomeView: View {
     let username: String
     @State private var tools: [Tool] = []
+    @State private var selectedView = 0
     
     var body: some View {
         NavigationStack {
@@ -11,16 +12,27 @@ struct WelcomeView: View {
                     .font(.largeTitle)
                     .bold()
                     .padding()
-                
-                List(tools) { tool in
-                    NavigationLink(destination: ToolDetailView(tool: tool)) {
-                        VStack(alignment: .leading) {
-                            Text(tool.name)
-                                .font(.headline)
-                            Text(tool.description ?? "No description available")
-                                .font(.subheadline)
+
+                Picker("View", selection: $selectedView) {
+                    Text("List").tag(0)
+                    Text("Map").tag(1)
+                }
+                .pickerStyle(.segmented)
+                .padding(.horizontal)
+
+                if selectedView == 0 {
+                    List(tools) { tool in
+                        NavigationLink(destination: ToolDetailView(tool: tool)) {
+                            VStack(alignment: .leading) {
+                                Text(tool.name)
+                                    .font(.headline)
+                                Text(tool.description ?? "No description available")
+                                    .font(.subheadline)
+                            }
                         }
                     }
+                } else {
+                    MapView()
                 }
             }
         }


### PR DESCRIPTION
## Summary
- show Apple Maps in a new `MapView`
- add segmented control to switch between list and map in `WelcomeView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_683a87be725c83288264fa9189bd3b93