### PR TITLE
Fix missing location permission prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # starter_ios_app
+
+This is a small SwiftUI starter project used for demonstration purposes.
+
+The app requests access to your location when the map is displayed. If permission is denied, the map defaults to showing San Francisco.

--- a/Starter/Starter.xcodeproj/project.pbxproj
+++ b/Starter/Starter.xcodeproj/project.pbxproj
@@ -413,11 +413,12 @@
 				PRODUCT_BUNDLE_IDENTIFIER = testing.app.Starter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
+                               SWIFT_VERSION = 5.0;
+                               TARGETED_DEVICE_FAMILY = "1,2";
+                               INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Your location is needed to show nearby tools on the map.";
+                       };
+                       name = Debug;
+               };
 		D6D5319D2DEA5980003BCA3B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -441,11 +442,12 @@
 				PRODUCT_BUNDLE_IDENTIFIER = testing.app.Starter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Release;
-		};
+                               SWIFT_VERSION = 5.0;
+                               TARGETED_DEVICE_FAMILY = "1,2";
+                               INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Your location is needed to show nearby tools on the map.";
+                       };
+                       name = Release;
+               };
 		D6D5319F2DEA5980003BCA3B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {


### PR DESCRIPTION
## Summary
- mention location usage in README
- add `NSLocationWhenInUseUsageDescription` to build settings so the OS will prompt for permission

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683a8fd9fa3083288818a20e6e4000bd