### PR TITLE
Enable login modal and guest mode

### DIFF
--- a/Starter/Starter/AccountView.swift
+++ b/Starter/Starter/AccountView.swift
@@ -2,24 +2,37 @@ import SwiftUI
 
 struct AccountView: View {
     let username: String
+    @Binding var showLogin: Bool
+    @AppStorage("authToken") private var authToken: String = ""
     @State private var user: User?
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 12) {
-                Text("Account Details")
-                    .font(.largeTitle)
-                    .padding(.bottom, 8)
+        if authToken.isEmpty {
+            VStack(spacing: 16) {
+                Text("You are not logged in.")
+                    .font(.title2)
+                Button("Log In") {
+                    showLogin = true
+                }
+                .buttonStyle(.borderedProminent)
+            }
+            .padding()
+        } else {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Account Details")
+                        .font(.largeTitle)
+                        .padding(.bottom, 8)
 
-                if let user = user {
-                    Group {
-                        Text("Username: \(user.username)")
-                            .font(.title2)
-                        Text("User ID: \(user.id)")
-                            .font(.title3)
-                        if let firstName = user.first_name {
-                            Text("First Name: \(firstName)")
-                        }
+                    if let user = user {
+                        Group {
+                            Text("Username: \(user.username)")
+                                .font(.title2)
+                            Text("User ID: \(user.id)")
+                                .font(.title3)
+                            if let firstName = user.first_name {
+                                Text("First Name: \(firstName)")
+                            }
                         if let lastName = user.last_name {
                             Text("Last Name: \(lastName)")
                         }
@@ -53,21 +66,22 @@ struct AccountView: View {
                         if let updated = user.updated_at {
                             Text("Updated: \(updated)")
                         }
+                        }
+                    } else {
+                        Text("Username: \(username)")
+                            .font(.title2)
+                        Text("Loading user info...")
+                            .foregroundColor(.secondary)
                     }
-                } else {
-                    Text("Username: \(username)")
-                        .font(.title2)
-                    Text("Loading user info...")
-                        .foregroundColor(.secondary)
                 }
+                .padding()
             }
-            .padding()
-        }
-        .onAppear {
-            fetchUsers { users in
-                if let match = users.first(where: { $0.username == username }) {
-                    DispatchQueue.main.async {
-                        self.user = match
+            .onAppear {
+                fetchUsers { users in
+                    if let match = users.first(where: { $0.username == username }) {
+                        DispatchQueue.main.async {
+                            self.user = match
+                        }
                     }
                 }
             }
@@ -76,5 +90,5 @@ struct AccountView: View {
 }
 
 #Preview {
-    AccountView(username: "daniel")
+    AccountView(username: "daniel", showLogin: .constant(false))
 }

--- a/Starter/Starter/ContentView.swift
+++ b/Starter/Starter/ContentView.swift
@@ -1,63 +1,17 @@
 import SwiftUI
 
+/// The entry view for the application. The main interface is always
+/// accessible. When the user is logged out a "Log In" button can present
+/// the login sheet.
 struct ContentView: View {
-    @State private var username: String = ""
-    @State private var password: String = ""
-    @State private var showingAlert = false
-    @State private var loggedIn = false
+    @AppStorage("username") private var storedUsername: String = "Guest"
+    @State private var showLogin = false
 
     var body: some View {
-        if loggedIn {
-            MainTabView(username: username)
-        } else {
-            loginForm
-        }
-    }
-
-    private var loginForm: some View {
-        ZStack {
-            LinearGradient(gradient: Gradient(colors: [.blue.opacity(0.6), .purple.opacity(0.6)]), startPoint: .top, endPoint: .bottom)
-                .ignoresSafeArea()
-            VStack(spacing: 20) {
-                Spacer()
-                Text("Log In")
-                    .font(.largeTitle)
-                    .bold()
-                    .foregroundColor(.white)
-                TextField("Username", text: $username)
-                    .textInputAutocapitalization(.never) // iOS 15+
-                    .autocapitalization(.none)           // backward compatibility
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                    .padding(.horizontal)
-
-                SecureField("Password", text: $password)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                    .padding(.horizontal)
-                Button(action: {
-                    login(username: username, password: password) { success in
-                        DispatchQueue.main.async {
-                            if success {
-                                loggedIn = true
-                            } else {
-                                showingAlert = true
-                            }
-                        }
-                    }
-                }) {
-                    Text("Log In")
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                        .background(Color.white.opacity(0.8))
-                        .foregroundColor(.blue)
-                        .cornerRadius(8)
-                        .padding(.horizontal)
-                }
-                Spacer()
+        MainTabView(username: storedUsername, showLogin: $showLogin)
+            .sheet(isPresented: $showLogin) {
+                LoginView(showLogin: $showLogin)
             }
-        }
-        .alert("Login failed", isPresented: $showingAlert) {
-            Button("OK", role: .cancel) {}
-        }
     }
 }
 

--- a/Starter/Starter/LoginView.swift
+++ b/Starter/Starter/LoginView.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+/// Modal view that handles user login.
+struct LoginView: View {
+    /// Controls presentation from the parent view.
+    @Binding var showLogin: Bool
+    @AppStorage("username") private var storedUsername: String = "Guest"
+    @AppStorage("authToken") private var authToken: String = ""
+    @State private var username: String = ""
+    @State private var password: String = ""
+    @State private var showingAlert = false
+
+    var body: some View {
+        ZStack {
+            LinearGradient(gradient: Gradient(colors: [.blue.opacity(0.6), .purple.opacity(0.6)]), startPoint: .top, endPoint: .bottom)
+                .ignoresSafeArea()
+            VStack(spacing: 20) {
+                Spacer()
+                Text("Log In")
+                    .font(.largeTitle)
+                    .bold()
+                    .foregroundColor(.white)
+                TextField("Username", text: $username)
+                    .textInputAutocapitalization(.never)
+                    .autocapitalization(.none)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .padding(.horizontal)
+                SecureField("Password", text: $password)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .padding(.horizontal)
+                Button(action: {
+                    login(username: username, password: password) { success in
+                        DispatchQueue.main.async {
+                            if success {
+                                storedUsername = username
+                                showLogin = false
+                            } else {
+                                showingAlert = true
+                            }
+                        }
+                    }
+                }) {
+                    Text("Log In")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.white.opacity(0.8))
+                        .foregroundColor(.blue)
+                        .cornerRadius(8)
+                        .padding(.horizontal)
+                }
+                Spacer()
+            }
+        }
+        .alert("Login failed", isPresented: $showingAlert) {
+            Button("OK", role: .cancel) {}
+        }
+    }
+}
+
+#Preview {
+    LoginView(showLogin: .constant(true))
+}

--- a/Starter/Starter/MainTabView.swift
+++ b/Starter/Starter/MainTabView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct MainTabView: View {
     let username: String
+    @Binding var showLogin: Bool
 
     var body: some View {
         TabView {
@@ -25,7 +26,7 @@ struct MainTabView: View {
                     Label("Listings", systemImage: "list.bullet")
                 }
 
-            AccountView(username: username)
+            AccountView(username: username, showLogin: $showLogin)
                 .tabItem {
                     Label("Account", systemImage: "person")
                 }
@@ -34,5 +35,5 @@ struct MainTabView: View {
 }
 
 #Preview {
-    MainTabView(username: "daniel")
+    MainTabView(username: "daniel", showLogin: .constant(false))
 }

--- a/Starter/Starter/Network.swift
+++ b/Starter/Starter/Network.swift
@@ -65,6 +65,7 @@ func login(username: String, password: String, completion: @escaping (Bool) -> V
         if let data = data,
            let auth = try? JSONDecoder().decode(AuthResponse.self, from: data) {
             UserDefaults.standard.set(auth.token, forKey: "authToken")
+            UserDefaults.standard.set(username, forKey: "username")
             print("Login success, token: \(auth.token)")
             completion(true)
         } else {


### PR DESCRIPTION
## Summary
- keep main app accessible even when logged out
- add a LoginView presented as a sheet
- show a login button in Account tab when logged out
- store username in defaults when logging in

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_683ab39a5854832884a965e66f2669b6