### PR TITLE
Add automatic login prompt

### DIFF
--- a/Starter/Starter/MainTabView.swift
+++ b/Starter/Starter/MainTabView.swift
@@ -53,6 +53,13 @@ struct MainTabView: View {
                 pendingSelection = nil
             }
         }
+        .onChange(of: authToken) { newValue in
+            if newValue.isEmpty && selection != 0 {
+                pendingSelection = selection
+                showLogin = true
+                selection = 0
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- present the login sheet if attempting to view a tab other than home
- monitor the auth token so the sheet reappears when logging out from a restricted tab

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_683ab76b820c8328a7258760602638aa