### PR TITLE
Fix auth token persistence and logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 This is a small SwiftUI starter project used for demonstration purposes.
 
 The app requests access to your location when the map is displayed. If permission is denied, the map defaults to showing San Francisco.
+
+## Authentication Persistence
+
+After logging in, the received authentication token is stored locally so you remain logged in when reopening the app. A new **Log Out** button in the account tab clears this token if you wish to sign out.

--- a/Starter/Starter/AccountView.swift
+++ b/Starter/Starter/AccountView.swift
@@ -75,6 +75,14 @@ struct AccountView: View {
                     }
                 }
                 .padding()
+
+                Button("Log Out") {
+                    logout()
+                    authToken = ""
+                    showLogin = false
+                }
+                .buttonStyle(.borderedProminent)
+                .padding(.top)
             }
             .onAppear {
                 fetchUsers { users in

--- a/Starter/Starter/Network.swift
+++ b/Starter/Starter/Network.swift
@@ -113,3 +113,9 @@ func fetchTools(completion: @escaping ([Tool]) -> Void) {
         }
     }.resume()
 }
+
+/// Clear the stored authentication token and user information.
+func logout() {
+    UserDefaults.standard.removeObject(forKey: "authToken")
+    UserDefaults.standard.removeObject(forKey: "username")
+}


### PR DESCRIPTION
## Summary
- persist auth token to keep user logged in when reopening the app
- add a logout helper in `Network.swift`
- show a **Log Out** button in `AccountView`
- document persistent login and logout in README

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_683b2c9448888328a05924ac19fc5c81