### PR TITLE
Handle login message consistently

### DIFF
--- a/Starter/Starter/ChatView.swift
+++ b/Starter/Starter/ChatView.swift
@@ -1,12 +1,28 @@
 import SwiftUI
 
 struct ChatView: View {
+    /// Controls presentation of the login sheet from the parent view.
+    @Binding var showLogin: Bool
+    @AppStorage("authToken") private var authToken: String = ""
+
     var body: some View {
-        Text("Chat")
-            .font(.largeTitle)
+        if authToken.isEmpty {
+            VStack(spacing: 16) {
+                Text("You are not logged in.")
+                    .font(.title2)
+                Button("Log In") {
+                    showLogin = true
+                }
+                .buttonStyle(.borderedProminent)
+            }
+            .padding()
+        } else {
+            Text("Chat")
+                .font(.largeTitle)
+        }
     }
 }
 
 #Preview {
-    ChatView()
+    ChatView(showLogin: .constant(false))
 }

--- a/Starter/Starter/ListingsView.swift
+++ b/Starter/Starter/ListingsView.swift
@@ -2,25 +2,40 @@ import SwiftUI
 
 struct ListingsView: View {
     let username: String
+    /// Controls presentation of the login sheet from the parent view.
+    @Binding var showLogin: Bool
+    @AppStorage("authToken") private var authToken: String = ""
     @State private var user: User?
     @State private var tools: [Tool] = []
 
     var body: some View {
-        NavigationStack {
-            List(filteredTools) { tool in
-                NavigationLink(destination: ToolDetailView(tool: tool)) {
-                    VStack(alignment: .leading) {
-                        Text(tool.name)
-                            .font(.headline)
-                        Text(tool.description ?? "No description available")
-                            .font(.subheadline)
+        if authToken.isEmpty {
+            VStack(spacing: 16) {
+                Text("You are not logged in.")
+                    .font(.title2)
+                Button("Log In") {
+                    showLogin = true
+                }
+                .buttonStyle(.borderedProminent)
+            }
+            .padding()
+        } else {
+            NavigationStack {
+                List(filteredTools) { tool in
+                    NavigationLink(destination: ToolDetailView(tool: tool)) {
+                        VStack(alignment: .leading) {
+                            Text(tool.name)
+                                .font(.headline)
+                            Text(tool.description ?? "No description available")
+                                .font(.subheadline)
+                        }
                     }
                 }
+                .navigationTitle("Listings")
             }
-            .navigationTitle("Listings")
-        }
-        .onAppear {
-            loadData()
+            .onAppear {
+                loadData()
+            }
         }
     }
 
@@ -46,5 +61,5 @@ struct ListingsView: View {
 }
 
 #Preview {
-    ListingsView(username: "User")
+    ListingsView(username: "User", showLogin: .constant(false))
 }

--- a/Starter/Starter/MainTabView.swift
+++ b/Starter/Starter/MainTabView.swift
@@ -3,8 +3,6 @@ import SwiftUI
 struct MainTabView: View {
     let username: String
     @Binding var showLogin: Bool
-    @AppStorage("authToken") private var authToken: String = ""
-
     @State private var selection = 0
 
     var body: some View {
@@ -15,37 +13,19 @@ struct MainTabView: View {
                 }
                 .tag(0)
 
-            Group {
-                if authToken.isEmpty {
-                    LoginView(showLogin: $showLogin)
-                } else {
-                    ChatView()
-                }
-            }
+            ChatView(showLogin: $showLogin)
             .tabItem {
                 Label("Chat", systemImage: "bubble.right")
             }
             .tag(1)
 
-            Group {
-                if authToken.isEmpty {
-                    LoginView(showLogin: $showLogin)
-                } else {
-                    PostView()
-                }
-            }
+            PostView(showLogin: $showLogin)
             .tabItem {
                 Label("Post", systemImage: "plus.app")
             }
             .tag(2)
 
-            Group {
-                if authToken.isEmpty {
-                    LoginView(showLogin: $showLogin)
-                } else {
-                    ListingsView(username: username)
-                }
-            }
+            ListingsView(username: username, showLogin: $showLogin)
             .tabItem {
                 Label("Listings", systemImage: "list.bullet")
             }

--- a/Starter/Starter/PostView.swift
+++ b/Starter/Starter/PostView.swift
@@ -1,12 +1,28 @@
 import SwiftUI
 
 struct PostView: View {
+    /// Controls presentation of the login sheet from the parent view.
+    @Binding var showLogin: Bool
+    @AppStorage("authToken") private var authToken: String = ""
+
     var body: some View {
-        Text("Post")
-            .font(.largeTitle)
+        if authToken.isEmpty {
+            VStack(spacing: 16) {
+                Text("You are not logged in.")
+                    .font(.title2)
+                Button("Log In") {
+                    showLogin = true
+                }
+                .buttonStyle(.borderedProminent)
+            }
+            .padding()
+        } else {
+            Text("Post")
+                .font(.largeTitle)
+        }
     }
 }
 
 #Preview {
-    PostView()
+    PostView(showLogin: .constant(false))
 }


### PR DESCRIPTION
## Summary
- add login prompt handling in ChatView, PostView and ListingsView
- show those views directly in MainTabView instead of swapping in LoginView
- pass `showLogin` binding around

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_b_683b2e5ded58832895380459dd7bba37