### PR TITLE
Style tabs and update theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,8 @@ After logging in, the received authentication token is stored locally so you rem
 
 The account tab now features a colorful gradient background with a large profile
 icon and user details presented inside a rounded card for a cleaner look.
+
+## Theme
+
+The application now uses a black and orange color scheme applied across all tab
+views for a consistent appearance.

--- a/Starter/Starter/AccountView.swift
+++ b/Starter/Starter/AccountView.swift
@@ -15,6 +15,7 @@ struct AccountView: View {
                     showLogin = true
                 }
                 .buttonStyle(.borderedProminent)
+                .tint(.orange)
             }
             .padding()
         } else {
@@ -98,17 +99,14 @@ struct AccountView: View {
                     .frame(maxWidth: .infinity)
                     .padding()
                     .background(Color.white.opacity(0.8))
-                    .foregroundColor(.blue)
+                    .foregroundColor(.orange)
                     .cornerRadius(8)
                     .padding(.horizontal)
                     .padding(.top)
                 }
                 .padding(.vertical)
             }
-            .background(
-                LinearGradient(gradient: Gradient(colors: [.blue.opacity(0.6), .purple.opacity(0.6)]), startPoint: .top, endPoint: .bottom)
-                    .ignoresSafeArea()
-            )
+            .applyThemeBackground()
             .onAppear {
                 fetchUsers { users in
                     if let match = users.first(where: { $0.username == username }) {

--- a/Starter/Starter/ChatView.swift
+++ b/Starter/Starter/ChatView.swift
@@ -6,20 +6,24 @@ struct ChatView: View {
     @AppStorage("authToken") private var authToken: String = ""
 
     var body: some View {
-        if authToken.isEmpty {
-            VStack(spacing: 16) {
-                Text("You are not logged in.")
-                    .font(.title2)
-                Button("Log In") {
-                    showLogin = true
+        ZStack {
+            if authToken.isEmpty {
+                VStack(spacing: 16) {
+                    Text("You are not logged in.")
+                        .font(.title2)
+                    Button("Log In") {
+                        showLogin = true
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.orange)
                 }
-                .buttonStyle(.borderedProminent)
+                .padding()
+            } else {
+                Text("Chat")
+                    .font(.largeTitle)
             }
-            .padding()
-        } else {
-            Text("Chat")
-                .font(.largeTitle)
         }
+        .applyThemeBackground()
     }
 }
 

--- a/Starter/Starter/ListingsView.swift
+++ b/Starter/Starter/ListingsView.swift
@@ -9,36 +9,40 @@ struct ListingsView: View {
     @State private var tools: [Tool] = []
 
     var body: some View {
-        if authToken.isEmpty {
-            VStack(spacing: 16) {
-                Text("You are not logged in.")
-                    .font(.title2)
-                Button("Log In") {
-                    showLogin = true
+        ZStack {
+            if authToken.isEmpty {
+                VStack(spacing: 16) {
+                    Text("You are not logged in.")
+                        .font(.title2)
+                    Button("Log In") {
+                        showLogin = true
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.orange)
                 }
-                .buttonStyle(.borderedProminent)
-            }
-            .padding()
-        } else {
-            NavigationStack {
-                List(filteredTools) { tool in
-                    NavigationLink(destination: ToolDetailView(tool: tool)) {
-                        VStack(alignment: .leading) {
-                            Text(tool.name)
-                                .font(.headline)
-                            Text(tool.description ?? "No description available")
-                                .font(.subheadline)
+                .padding()
+            } else {
+                NavigationStack {
+                    List(filteredTools) { tool in
+                        NavigationLink(destination: ToolDetailView(tool: tool)) {
+                            VStack(alignment: .leading) {
+                                Text(tool.name)
+                                    .font(.headline)
+                                Text(tool.description ?? "No description available")
+                                    .font(.subheadline)
+                            }
                         }
                     }
+                    .listStyle(.plain)
+                    .navigationTitle("RNTL")
+                    .navigationBarTitleDisplayMode(.inline)
                 }
-                .listStyle(.plain)
-            .navigationTitle("RNTL")
-            .navigationBarTitleDisplayMode(.inline)
-            }
-            .onAppear {
-                loadData()
+                .onAppear {
+                    loadData()
+                }
             }
         }
+        .applyThemeBackground()
     }
 
     private var filteredTools: [Tool] {

--- a/Starter/Starter/LoginView.swift
+++ b/Starter/Starter/LoginView.swift
@@ -12,8 +12,12 @@ struct LoginView: View {
 
     var body: some View {
         ZStack {
-            LinearGradient(gradient: Gradient(colors: [.blue.opacity(0.6), .purple.opacity(0.6)]), startPoint: .top, endPoint: .bottom)
-                .ignoresSafeArea()
+            LinearGradient(
+                gradient: Gradient(colors: [Color.black.opacity(0.6), Color.orange.opacity(0.6)]),
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .ignoresSafeArea()
             VStack(spacing: 20) {
                 Spacer()
                 Text("Log In")
@@ -44,10 +48,11 @@ struct LoginView: View {
                         .frame(maxWidth: .infinity)
                         .padding()
                         .background(Color.white.opacity(0.8))
-                        .foregroundColor(.blue)
+                        .foregroundColor(.orange)
                         .cornerRadius(8)
                         .padding(.horizontal)
                 }
+                .tint(.orange)
                 Spacer()
             }
         }

--- a/Starter/Starter/PostView.swift
+++ b/Starter/Starter/PostView.swift
@@ -6,20 +6,24 @@ struct PostView: View {
     @AppStorage("authToken") private var authToken: String = ""
 
     var body: some View {
-        if authToken.isEmpty {
-            VStack(spacing: 16) {
-                Text("You are not logged in.")
-                    .font(.title2)
-                Button("Log In") {
-                    showLogin = true
+        ZStack {
+            if authToken.isEmpty {
+                VStack(spacing: 16) {
+                    Text("You are not logged in.")
+                        .font(.title2)
+                    Button("Log In") {
+                        showLogin = true
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.orange)
                 }
-                .buttonStyle(.borderedProminent)
+                .padding()
+            } else {
+                Text("Post")
+                    .font(.largeTitle)
             }
-            .padding()
-        } else {
-            Text("Post")
-                .font(.largeTitle)
         }
+        .applyThemeBackground()
     }
 }
 

--- a/Starter/Starter/StarterApp.swift
+++ b/Starter/Starter/StarterApp.swift
@@ -12,6 +12,7 @@ struct StarterApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .accentColor(.orange)
         }
     }
 }

--- a/Starter/Starter/Theme.swift
+++ b/Starter/Starter/Theme.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct BlackOrangeBackground: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .background(
+                LinearGradient(
+                    gradient: Gradient(colors: [Color.black.opacity(0.6), Color.orange.opacity(0.6)]),
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+                .ignoresSafeArea()
+            )
+    }
+}
+
+extension View {
+    func applyThemeBackground() -> some View {
+        self.modifier(BlackOrangeBackground())
+    }
+}

--- a/Starter/Starter/WelcomeView.swift
+++ b/Starter/Starter/WelcomeView.swift
@@ -6,8 +6,9 @@ struct WelcomeView: View {
     @State private var selectedView = 0
 
     var body: some View {
-        NavigationStack {
-            VStack(spacing: 0) {
+        ZStack {
+            NavigationStack {
+                VStack(spacing: 0) {
                 // 1) Put the segmented control inside a VStack of fixed height,
                 //    then give it a white (or .thickMaterial) background.
                 VStack {
@@ -43,6 +44,7 @@ struct WelcomeView: View {
             .navigationTitle("RNTL")
             .navigationBarTitleDisplayMode(.inline)
         }
+        .applyThemeBackground()
         .onAppear {
             fetchTools { fetched in
                 DispatchQueue.main.async {


### PR DESCRIPTION
## Summary
- add a reusable black/orange gradient modifier
- apply theme in Account, Chat, Listings, Post, and Welcome views
- set accent color to orange
- update login screen gradient and colors
- document the new theme in README

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b37b46f4083288bed54463da8bf83