### PR TITLE
Fix grey background in Tab and Nav bars

### DIFF
--- a/Starter/Starter/StarterApp.swift
+++ b/Starter/Starter/StarterApp.swift
@@ -6,9 +6,32 @@
 //
 
 import SwiftUI
+import UIKit
 
 @main
 struct StarterApp: App {
+    init() {
+        // Make tab and navigation bars transparent so the gradient background
+        // shows through instead of the default gray color.
+        let tabAppearance = UITabBarAppearance()
+        tabAppearance.configureWithTransparentBackground()
+        tabAppearance.backgroundColor = .clear
+        UITabBar.appearance().standardAppearance = tabAppearance
+        if #available(iOS 15.0, *) {
+            UITabBar.appearance().scrollEdgeAppearance = tabAppearance
+        }
+        UITabBar.appearance().tintColor = .orange
+
+        let navAppearance = UINavigationBarAppearance()
+        navAppearance.configureWithTransparentBackground()
+        navAppearance.backgroundColor = .clear
+        navAppearance.titleTextAttributes = [.foregroundColor: UIColor.orange]
+        navAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor.orange]
+        UINavigationBar.appearance().standardAppearance = navAppearance
+        UINavigationBar.appearance().scrollEdgeAppearance = navAppearance
+        UINavigationBar.appearance().compactAppearance = navAppearance
+    }
+
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/Starter/Starter/StarterApp.swift
+++ b/Starter/Starter/StarterApp.swift
@@ -15,7 +15,7 @@ struct StarterApp: App {
         // shows through instead of the default gray color.
         let tabAppearance = UITabBarAppearance()
         tabAppearance.configureWithTransparentBackground()
-        tabAppearance.backgroundColor = .clear
+        tabAppearance.backgroundColor = .black
         UITabBar.appearance().standardAppearance = tabAppearance
         if #available(iOS 15.0, *) {
             UITabBar.appearance().scrollEdgeAppearance = tabAppearance
@@ -24,12 +24,17 @@ struct StarterApp: App {
 
         let navAppearance = UINavigationBarAppearance()
         navAppearance.configureWithTransparentBackground()
-        navAppearance.backgroundColor = .clear
+        navAppearance.backgroundColor = .black
         navAppearance.titleTextAttributes = [.foregroundColor: UIColor.orange]
         navAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor.orange]
         UINavigationBar.appearance().standardAppearance = navAppearance
         UINavigationBar.appearance().scrollEdgeAppearance = navAppearance
         UINavigationBar.appearance().compactAppearance = navAppearance
+        
+        UISegmentedControl.appearance().selectedSegmentTintColor = UIColor.orange
+        UISegmentedControl.appearance().backgroundColor = UIColor.black
+        UISegmentedControl.appearance().setTitleTextAttributes([.foregroundColor: UIColor.orange], for: .normal)
+        UISegmentedControl.appearance().setTitleTextAttributes([.foregroundColor: UIColor.black], for: .selected)
     }
 
     var body: some Scene {

--- a/Starter/Starter/WelcomeView.swift
+++ b/Starter/Starter/WelcomeView.swift
@@ -9,17 +9,19 @@ struct WelcomeView: View {
         ZStack {
             NavigationStack {
                 VStack(spacing: 0) {
-                    // 1) Put the segmented control inside a VStack of fixed height,
-                    //    then give it a white (or .thickMaterial) background.
                     VStack {
                         Picker("View", selection: $selectedView) {
                             Text("List").tag(0)
                             Text("Map").tag(1)
                         }
                         .pickerStyle(.segmented)
-                        .padding(.horizontal)
+                        .padding()
+                        .background(Color.black)
+                        .tint(.orange)
                     }
-                    .frame(height: 48) // adjust if you need more/less vertical space
+                    .background(Color.black)
+                    .frame(height: 60)
+                    
                     
                     // 2) Now show either the List or the Map below it
                     if selectedView == 0 {


### PR DESCRIPTION
## Summary
- make tab bar and navigation bar transparent to stop light grey from showing when scrolling

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_b_683b4b110b048328b2825011ca57b2a8