### PR TITLE
Fix nav/tab bar colors

### DIFF
--- a/Starter/Starter/MapView.swift
+++ b/Starter/Starter/MapView.swift
@@ -27,14 +27,7 @@ struct MapView: View {
             UINavigationBar.appearance().compactAppearance = navAppearance
         }
         .onDisappear {
-            let navAppearance = UINavigationBarAppearance()
-            navAppearance.configureWithTransparentBackground()
-            navAppearance.backgroundColor = .black
-            navAppearance.titleTextAttributes = [.foregroundColor: UIColor.orange]
-            navAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor.orange]
-            UINavigationBar.appearance().standardAppearance = navAppearance
-            UINavigationBar.appearance().scrollEdgeAppearance = navAppearance
-            UINavigationBar.appearance().compactAppearance = navAppearance
+            // Keep global black navigation bar style when leaving the map view.
         }
         .onReceive(locationManager.$location) { location in
             if let location {

--- a/Starter/Starter/StarterApp.swift
+++ b/Starter/Starter/StarterApp.swift
@@ -11,10 +11,9 @@ import UIKit
 @main
 struct StarterApp: App {
     init() {
-        // Make tab and navigation bars transparent so the gradient background
-        // shows through instead of the default gray color.
+        // Make tab and navigation bars black to match the theme.
         let tabAppearance = UITabBarAppearance()
-        tabAppearance.configureWithTransparentBackground()
+        tabAppearance.configureWithOpaqueBackground()
         tabAppearance.backgroundColor = .black
         UITabBar.appearance().standardAppearance = tabAppearance
         if #available(iOS 15.0, *) {
@@ -23,13 +22,14 @@ struct StarterApp: App {
         UITabBar.appearance().tintColor = .orange
 
         let navAppearance = UINavigationBarAppearance()
-        navAppearance.configureWithTransparentBackground()
+        navAppearance.configureWithOpaqueBackground()
         navAppearance.backgroundColor = .black
         navAppearance.titleTextAttributes = [.foregroundColor: UIColor.orange]
         navAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor.orange]
         UINavigationBar.appearance().standardAppearance = navAppearance
         UINavigationBar.appearance().scrollEdgeAppearance = navAppearance
         UINavigationBar.appearance().compactAppearance = navAppearance
+        UINavigationBar.appearance().tintColor = .orange
         
         UISegmentedControl.appearance().selectedSegmentTintColor = UIColor.orange
         UISegmentedControl.appearance().backgroundColor = UIColor.black


### PR DESCRIPTION
## Summary
- keep map navigation bar black when shown
- set tab and navigation bar appearances to black globally

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_b_683b596d8dd88328a7f447268b390d47