### PR TITLE
Allow manual map scrolling

### DIFF
--- a/Starter/Starter/MapView.swift
+++ b/Starter/Starter/MapView.swift
@@ -1,7 +1,10 @@
 import SwiftUI
 import MapKit
 
-/// Displays a map that follows the user's current location.
+/// Displays a map centered on the user's location when first shown.
+///
+/// After the initial centering the user is free to pan/zoom the map
+/// without it snapping back to their current position.
 struct MapView: View {
     @StateObject private var locationManager = LocationManager()
     @State private var position = MapCameraPosition.region(
@@ -10,6 +13,8 @@ struct MapView: View {
             span: MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
         )
     )
+    /// Tracks whether we've already centered the map on the user's location.
+    @State private var hasCentered = false
 
     var body: some View {
         Map(position: $position) {
@@ -17,15 +22,15 @@ struct MapView: View {
         }
         .edgesIgnoringSafeArea(.all)
         .onReceive(locationManager.$location) { location in
-            if let location {
-                withAnimation {
-                    position = .region(
-                        MKCoordinateRegion(
-                            center: location,
-                            span: MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
-                        )
+            // Only center on the user's location the first time we obtain it.
+            if let location, !hasCentered {
+                position = .region(
+                    MKCoordinateRegion(
+                        center: location,
+                        span: MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
                     )
-                }
+                )
+                hasCentered = true
             }
         }
     }


### PR DESCRIPTION
## Summary
- update `MapView` to only center on the user once so the user can pan around without the map snapping back

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_685b638996048328a601f4ace9b8f968