### PR TITLE
Add auth token header when creating tools

### DIFF
--- a/Starter/Starter/MainTabView.swift
+++ b/Starter/Starter/MainTabView.swift
@@ -4,6 +4,7 @@ struct MainTabView: View {
     let username: String
     @Binding var showLogin: Bool
     @State private var selection = 0
+    @State private var previousSelection = 0
 
     var body: some View {
         TabView(selection: $selection) {
@@ -19,7 +20,7 @@ struct MainTabView: View {
             }
             .tag(1)
 
-            PostView(showLogin: $showLogin)
+            PostView(showLogin: $showLogin, selection: $selection, previousSelection: $previousSelection)
             .tabItem {
                 Label("Post", systemImage: "plus.app")
             }
@@ -36,6 +37,11 @@ struct MainTabView: View {
                 Label("Account", systemImage: "person")
             }
             .tag(4)
+        }
+        .onChange(of: selection) { newValue in
+            if newValue != 2 {
+                previousSelection = newValue
+            }
         }
     }
 }

--- a/Starter/Starter/Network.swift
+++ b/Starter/Starter/Network.swift
@@ -119,3 +119,33 @@ func logout() {
     UserDefaults.standard.removeObject(forKey: "authToken")
     UserDefaults.standard.removeObject(forKey: "username")
 }
+
+/// Create a new tool on the server.
+func createTool(name: String, price: String, description: String, ownerId: Int, createdAt: String, authToken: String, completion: @escaping (Bool) -> Void) {
+    guard let url = URL(string: "https://starter-ios-app-backend.onrender.com/tools") else {
+        completion(false)
+        return
+    }
+
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
+
+    let body: [String: Any] = [
+        "name": name,
+        "price": price,
+        "description": description,
+        "owner_id": ownerId,
+        "created_at": createdAt
+    ]
+    request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+    URLSession.shared.dataTask(with: request) { _, response, _ in
+        if let http = response as? HTTPURLResponse, http.statusCode == 201 {
+            completion(true)
+        } else {
+            completion(false)
+        }
+    }.resume()
+}

--- a/Starter/Starter/PostView.swift
+++ b/Starter/Starter/PostView.swift
@@ -32,31 +32,30 @@ struct PostView: View {
             } else {
                 NavigationStack {
                     Form {
-                        Section {
+                        Section (header: Text("Tool Information")) {
                             TextField("Name", text: $name)
                             TextField("Price", text: $price)
                                 .keyboardType(.decimalPad)
                             TextField("Description", text: $description, axis: .vertical)
                         }
                         Section {
-                            HStack {
+                            HStack() {
                                 Spacer()
-                                Button("Save") { savePost() }
-                                    .buttonStyle(.borderedProminent)
-                                Spacer()
-                            }
-                            HStack {
-                                Spacer()
+                                Button("Save") {
+                                    savePost()
+                                }
+                                .buttonStyle(.borderedProminent)
                                 Button("Cancel") {
                                     selection = previousSelection
                                 }
                                 .buttonStyle(.bordered)
                                 Spacer()
                             }
+                            .padding()
                         }
                     }
+                    .accentColor(.purple)
                     .navigationTitle("New Listing")
-                    .navigationBarTitleDisplayMode(.inline)
                 }
             }
         }

--- a/Starter/Starter/PostView.swift
+++ b/Starter/Starter/PostView.swift
@@ -3,7 +3,18 @@ import SwiftUI
 struct PostView: View {
     /// Controls presentation of the login sheet from the parent view.
     @Binding var showLogin: Bool
+    /// Binding to the selected tab from `MainTabView` so the view can switch
+    /// tabs when canceling or after saving a post.
+    @Binding var selection: Int
+    /// Stores the previously selected tab so we can return to it.
+    @Binding var previousSelection: Int
+
     @AppStorage("authToken") private var authToken: String = ""
+    @AppStorage("username") private var username: String = "Guest"
+
+    @State private var name = ""
+    @State private var price = ""
+    @State private var description = ""
 
     var body: some View {
         ZStack {
@@ -19,15 +30,62 @@ struct PostView: View {
                 }
                 .padding()
             } else {
-                Text("Post")
-                    .font(.largeTitle)
+                NavigationStack {
+                    Form {
+                        Section {
+                            TextField("Name", text: $name)
+                            TextField("Price", text: $price)
+                                .keyboardType(.decimalPad)
+                            TextField("Description", text: $description, axis: .vertical)
+                        }
+                        Section {
+                            HStack {
+                                Spacer()
+                                Button("Save") { savePost() }
+                                    .buttonStyle(.borderedProminent)
+                                Spacer()
+                            }
+                            HStack {
+                                Spacer()
+                                Button("Cancel") {
+                                    selection = previousSelection
+                                }
+                                .buttonStyle(.bordered)
+                                Spacer()
+                            }
+                        }
+                    }
+                    .navigationTitle("New Listing")
+                    .navigationBarTitleDisplayMode(.inline)
+                }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .applyThemeBackground()
     }
+
+    /// Save the entered data to the server and return to the previous tab on success.
+    private func savePost() {
+        fetchUsers { users in
+            guard let match = users.first(where: { $0.username == username }) else {
+                return
+            }
+            let ownerId = match.id
+            let createdAt = ISO8601DateFormatter().string(from: Date())
+            createTool(name: name, price: price, description: description, ownerId: ownerId, createdAt: createdAt, authToken: authToken) { success in
+                if success {
+                    DispatchQueue.main.async {
+                        name = ""
+                        price = ""
+                        description = ""
+                        selection = previousSelection
+                    }
+                }
+            }
+        }
+    }
 }
 
 #Preview {
-    PostView(showLogin: .constant(false))
+    PostView(showLogin: .constant(false), selection: .constant(2), previousSelection: .constant(0))
 }


### PR DESCRIPTION
## Summary
- include Authorization header in `createTool`
- pass stored auth token when saving posts

## Testing
- `swift --version`
- `swiftc Starter/Starter/PostView.swift -o /tmp/test 2>&1 | head` *(fails: no module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_b_685b64c996588328b759c42d61da7f8b