### PR TITLE
Add address search suggestions to post view

### DIFF
--- a/Starter/Starter/AddressSearchField.swift
+++ b/Starter/Starter/AddressSearchField.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+import MapKit
+
+struct AddressSearchField: View {
+    @ObservedObject var service: AddressSearchService
+    @Binding var selectedAddress: String
+    @Binding var selectedCoordinate: CLLocationCoordinate2D?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ZStack(alignment: .leading) {
+                TextField("", text: $service.query)
+                    .padding()
+                    .background(Color.black.opacity(0.4))
+                    .foregroundColor(.white)
+                    .cornerRadius(8)
+                    .padding(.horizontal, 18)
+                if service.query.isEmpty {
+                    Text("Address")
+                        .foregroundColor(.gray.opacity(0.4))
+                        .padding(.horizontal, 26)
+                }
+            }
+            if !service.results.isEmpty && service.query != selectedAddress {
+                List(service.results, id: \.self) { completion in
+                    VStack(alignment: .leading) {
+                        Text(completion.title)
+                            .foregroundColor(.white)
+                        if !completion.subtitle.isEmpty {
+                            Text(completion.subtitle)
+                                .font(.caption)
+                                .foregroundColor(.gray)
+                        }
+                    }
+                    .listRowBackground(Color.black.opacity(0.6))
+                    .onTapGesture {
+                        select(completion)
+                    }
+                }
+                .listStyle(.plain)
+                .frame(maxHeight: 150)
+            }
+        }
+    }
+
+    private func select(_ completion: MKLocalSearchCompletion) {
+        let request = MKLocalSearch.Request(completion: completion)
+        MKLocalSearch(request: request).start { response, _ in
+            if let coordinate = response?.mapItems.first?.placemark.coordinate {
+                DispatchQueue.main.async {
+                    self.selectedCoordinate = coordinate
+                    self.selectedAddress = completion.title + (completion.subtitle.isEmpty ? "" : ", \(completion.subtitle)")
+                    service.query = self.selectedAddress
+                    service.results = []
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    AddressSearchField(service: AddressSearchService(), selectedAddress: .constant(""), selectedCoordinate: .constant(nil))
+        .applyThemeBackground()
+}

--- a/Starter/Starter/AddressSearchService.swift
+++ b/Starter/Starter/AddressSearchService.swift
@@ -1,0 +1,24 @@
+import Foundation
+import MapKit
+
+class AddressSearchService: NSObject, ObservableObject, MKLocalSearchCompleterDelegate {
+    @Published var query: String = "" {
+        didSet {
+            completer.queryFragment = query
+        }
+    }
+    @Published var results: [MKLocalSearchCompletion] = []
+
+    private let completer: MKLocalSearchCompleter
+
+    override init() {
+        self.completer = MKLocalSearchCompleter()
+        super.init()
+        completer.delegate = self
+        completer.resultTypes = .address
+    }
+
+    func completerDidUpdateResults(_ completer: MKLocalSearchCompleter) {
+        results = completer.results
+    }
+}

--- a/Starter/Starter/PostView.swift
+++ b/Starter/Starter/PostView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import MapKit
 
 struct PostView: View {
     /// Controls presentation of the login sheet from the parent view.
@@ -16,6 +17,9 @@ struct PostView: View {
     @State private var price: Double = 0.0
     @State private var description = ""
     
+    @StateObject private var addressService = AddressSearchService()
+    @State private var address = ""
+    @State private var selectedCoordinate: CLLocationCoordinate2D?
     private var currencyFormatter: NumberFormatter {
         let formatter = NumberFormatter()
         formatter.numberStyle = .currency
@@ -73,6 +77,7 @@ struct PostView: View {
                                         .foregroundColor(.gray.opacity(0.4))
                                 }
                             }
+                            AddressSearchField(service: addressService, selectedAddress: $address, selectedCoordinate: $selectedCoordinate)
                             Text("Price")
                                 .font(.system(size: 18))
                                 .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
## Summary
- enable address autocompletion with `AddressSearchService`
- display a search bar for addresses in `PostView`
- save the selected address and its coordinates

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_685cc4a4be5c83289a2e2d62fcfa8739