### PR TITLE
Add keyboard dismissal for PostView

### DIFF
--- a/Starter/Starter/PostView.swift
+++ b/Starter/Starter/PostView.swift
@@ -125,6 +125,10 @@ struct PostView: View {
                             .bold()
                             .font(.title3)
                         }
+                        ToolbarItemGroup(placement: .keyboard) {
+                            Spacer()
+                            Button("Done") { hideKeyboard() }
+                        }
                     }
                 }
             }

--- a/Starter/Starter/View+HideKeyboard.swift
+++ b/Starter/Starter/View+HideKeyboard.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+#if canImport(UIKit)
+extension View {
+    /// Dismisses the system keyboard for this application.
+    func hideKeyboard() {
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add a helper extension to hide the keyboard from SwiftUI
- provide a Done button on the keyboard in `PostView`

## Testing
- `swiftc --version`

------
https://chatgpt.com/codex/tasks/task_b_685cc9dfa0988328866ec24858e7d862