### PR TITLE
Add keyboard dismissal option on post view

### DIFF
--- a/Starter/Starter/KeyboardDismiss.swift
+++ b/Starter/Starter/KeyboardDismiss.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+#if canImport(UIKit)
+extension View {
+    /// Hides the currently presented keyboard, if any.
+    func hideKeyboard() {
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }
+}
+#endif

--- a/Starter/Starter/PostView.swift
+++ b/Starter/Starter/PostView.swift
@@ -125,6 +125,13 @@ struct PostView: View {
                             .bold()
                             .font(.title3)
                         }
+                        ToolbarItemGroup(placement: .keyboard) {
+                            Spacer()
+                            Button("Done") { hideKeyboard() }
+                        }
+                    }
+                    .onTapGesture {
+                        hideKeyboard()
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- implement a small extension to hide the keyboard
- add a keyboard toolbar and tap gesture to PostView so the keyboard can be dismissed

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_b_685cc9dfa0988328866ec24858e7d862