### PR TITLE
Add keyboard dismissal for PostView

### DIFF
--- a/Starter/Starter/KeyboardDismissExtension.swift
+++ b/Starter/Starter/KeyboardDismissExtension.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+#if canImport(UIKit)
+import UIKit
+
+extension View {
+    /// Dismisses the on-screen keyboard.
+    func hideKeyboard() {
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }
+}
+#endif

--- a/Starter/Starter/PostView.swift
+++ b/Starter/Starter/PostView.swift
@@ -125,8 +125,15 @@ struct PostView: View {
                             .bold()
                             .font(.title3)
                         }
+                        ToolbarItemGroup(placement: .keyboard) {
+                            Spacer()
+                            Button("Done") {
+                                hideKeyboard()
+                            }
+                        }
                     }
                 }
+                .gesture(TapGesture().onEnded { hideKeyboard() })
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Starter/Starter/PostView.swift
+++ b/Starter/Starter/PostView.swift
@@ -110,26 +110,26 @@ struct PostView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .applyThemeBackground()
                     .tint(.purple)
-                    .toolbar {
-                        ToolbarItem(placement: .navigationBarTrailing) {
-                            Button("Cancel") {
-                                selection = previousSelection
-                            }
-                            .foregroundStyle(Color.red)
+                }
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Button("Cancel") {
+                            selection = previousSelection
                         }
-                        ToolbarItem(placement: .navigationBarLeading) {
-                            Button("Save") {
-                                savePost()
-                            }
-                            .foregroundStyle(Color.purple)
-                            .bold()
-                            .font(.title3)
+                        .foregroundStyle(Color.red)
+                    }
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        Button("Save") {
+                            savePost()
                         }
-                        ToolbarItemGroup(placement: .keyboard) {
-                            Spacer()
-                            Button("Done") {
-                                hideKeyboard()
-                            }
+                        .foregroundStyle(Color.purple)
+                        .bold()
+                        .font(.title3)
+                    }
+                    ToolbarItemGroup(placement: .keyboard) {
+                        Spacer()
+                        Button("Done") {
+                            hideKeyboard()
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- add a View extension to dismiss the keyboard
- show a "Done" button above the keyboard
- hide the keyboard when tapping outside fields

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_685cc9dfa0988328866ec24858e7d862