### PR TITLE
Fix address suggestion visibility

### DIFF
--- a/Starter/Starter/PostView.swift
+++ b/Starter/Starter/PostView.swift
@@ -43,7 +43,8 @@ struct PostView: View {
                 .padding()
             } else {
                 NavigationStack {
-                    VStack (spacing: 16){
+                    ScrollView {
+                        VStack (spacing: 16){
                         Text("New Listing")
                             .font(.title)
                             .bold()
@@ -105,8 +106,11 @@ struct PostView: View {
                         .shadow(radius: 8)
                         .cornerRadius(8)
                         
-                        Spacer()
+                            Spacer()
+                        }
+                        .frame(maxWidth: .infinity)
                     }
+                    .scrollDismissesKeyboard(.interactively)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .applyThemeBackground()
                     .tint(.purple)


### PR DESCRIPTION
## Summary
- wrap new listing fields in a `ScrollView`
- dismiss keyboard interactively while scrolling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685cc9b95ce08328a976f1e27bd14793