### PR TITLE
Fix address suggestions hidden by keyboard

### DIFF
--- a/Starter/Starter/PostView.swift
+++ b/Starter/Starter/PostView.swift
@@ -43,7 +43,8 @@ struct PostView: View {
                 .padding()
             } else {
                 NavigationStack {
-                    VStack (spacing: 16){
+                    ScrollView {
+                        VStack (spacing: 16){
                         Text("New Listing")
                             .font(.title)
                             .bold()
@@ -107,7 +108,9 @@ struct PostView: View {
                         
                         Spacer()
                     }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .frame(maxWidth: .infinity)
+                    .padding(.bottom, 16)
+                    }
                     .applyThemeBackground()
                     .tint(.purple)
                     .toolbar {


### PR DESCRIPTION
## Summary
- wrap PostView form in `ScrollView` so lists are scrollable when the keyboard appears

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_685cc9b95ce08328a976f1e27bd14793