### PR TITLE
Enable scrolling to see address search results

### DIFF
--- a/Starter/Starter/PostView.swift
+++ b/Starter/Starter/PostView.swift
@@ -43,7 +43,8 @@ struct PostView: View {
                 .padding()
             } else {
                 NavigationStack {
-                    VStack (spacing: 16){
+                    ScrollView {
+                        VStack(spacing: 16) {
                         Text("New Listing")
                             .font(.title)
                             .bold()
@@ -105,11 +106,14 @@ struct PostView: View {
                         .shadow(radius: 8)
                         .cornerRadius(8)
                         
-                        Spacer()
+                            Spacer()
+                        }
+                        .padding(.bottom, 20)
                     }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .frame(maxWidth: .infinity)
                     .applyThemeBackground()
                     .tint(.purple)
+                    .scrollDismissesKeyboard(.interactively)
                     .toolbar {
                         ToolbarItem(placement: .navigationBarTrailing) {
                             Button("Cancel") {


### PR DESCRIPTION
## Summary
- wrap the New Listing form in a `ScrollView`
- add `.scrollDismissesKeyboard(.interactively)` so the keyboard doesn't block results

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_b_685cd3558810832894e16f342864f0a0