### PR TITLE
Enable results visible while typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ icon and user details presented inside a rounded card for a cleaner look.
 
 The application now uses a black and orange color scheme applied across all tab
 views for a consistent appearance.
+
+## Posting Tools
+
+The new listing screen now scrolls while the keyboard is visible, allowing address search results to remain visible without dismissing the keyboard.

--- a/Starter/Starter/AddressSearchField.swift
+++ b/Starter/Starter/AddressSearchField.swift
@@ -22,22 +22,27 @@ struct AddressSearchField: View {
                 }
             }
             if !service.results.isEmpty && service.query != selectedAddress {
-                List(service.results, id: \.self) { completion in
-                    VStack(alignment: .leading) {
-                        Text(completion.title)
-                            .foregroundColor(.white)
-                        if !completion.subtitle.isEmpty {
-                            Text(completion.subtitle)
-                                .font(.caption)
-                                .foregroundColor(.gray)
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(service.results, id: \.self) { completion in
+                            VStack(alignment: .leading) {
+                                Text(completion.title)
+                                    .foregroundColor(.white)
+                                if !completion.subtitle.isEmpty {
+                                    Text(completion.subtitle)
+                                        .font(.caption)
+                                        .foregroundColor(.gray)
+                                }
+                            }
+                            .padding(.vertical, 8)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(Color.black.opacity(0.6))
+                            .onTapGesture {
+                                select(completion)
+                            }
                         }
                     }
-                    .listRowBackground(Color.black.opacity(0.6))
-                    .onTapGesture {
-                        select(completion)
-                    }
                 }
-                .listStyle(.plain)
                 .frame(maxHeight: 150)
             }
         }

--- a/Starter/Starter/PostView.swift
+++ b/Starter/Starter/PostView.swift
@@ -43,7 +43,8 @@ struct PostView: View {
                 .padding()
             } else {
                 NavigationStack {
-                    VStack (spacing: 16){
+                    ScrollView {
+                        VStack(spacing: 16) {
                         Text("New Listing")
                             .font(.title)
                             .bold()
@@ -93,20 +94,23 @@ struct PostView: View {
                                 .cornerRadius(8.0)
                                 .padding(.horizontal, 18)
                         }
-                        Button(action: {
-                            savePost()
-                        }) {
-                            Text("Save")
-                                .padding(8)
-                                .frame(width: 200)
+                            Button(action: {
+                                savePost()
+                            }) {
+                                Text("Save")
+                                    .padding(8)
+                                    .frame(width: 200)
+                            }
+                            .font(.title)
+                            .background(Color.black.opacity(0.4))
+                            .shadow(radius: 8)
+                            .cornerRadius(8)
+
+                            Spacer()
                         }
-                        .font(.title)
-                        .background(Color.black.opacity(0.4))
-                        .shadow(radius: 8)
-                        .cornerRadius(8)
-                        
-                        Spacer()
+                        .frame(maxWidth: .infinity)
                     }
+                    .scrollDismissesKeyboard(.interactively)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .applyThemeBackground()
                     .tint(.purple)


### PR DESCRIPTION
## Summary
- make PostView scrollable and dismiss keyboard interactively
- change AddressSearchField results to use a ScrollView
- document address search usability improvement

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_685cd3558810832894e16f342864f0a0