### PR TITLE
Improve search results visibility during typing

### DIFF
--- a/Starter/Starter/AddressSearchField.swift
+++ b/Starter/Starter/AddressSearchField.swift
@@ -5,6 +5,7 @@ struct AddressSearchField: View {
     @ObservedObject var service: AddressSearchService
     @Binding var selectedAddress: String
     @Binding var selectedCoordinate: CLLocationCoordinate2D?
+    @StateObject private var keyboard = KeyboardResponder()
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -41,6 +42,7 @@ struct AddressSearchField: View {
                 .frame(maxHeight: 150)
             }
         }
+        .padding(.bottom, keyboard.keyboardHeight)
     }
 
     private func select(_ completion: MKLocalSearchCompletion) {

--- a/Starter/Starter/KeyboardResponder.swift
+++ b/Starter/Starter/KeyboardResponder.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+import Combine
+
+/// Observes keyboard notifications and publishes the current keyboard height.
+final class KeyboardResponder: ObservableObject {
+    @Published var keyboardHeight: CGFloat = 0
+
+    private var cancellables: Set<AnyCancellable> = []
+
+    init() {
+        let willShow = NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)
+            .compactMap { $0.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect }
+            .map { $0.height }
+
+        let willHide = NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)
+            .map { _ in CGFloat(0) }
+
+        Publishers.Merge(willShow, willHide)
+            .receive(on: RunLoop.main)
+            .assign(to: &self.$keyboardHeight)
+    }
+}

--- a/Starter/Starter/PostView.swift
+++ b/Starter/Starter/PostView.swift
@@ -20,6 +20,7 @@ struct PostView: View {
     @StateObject private var addressService = AddressSearchService()
     @State private var address = ""
     @State private var selectedCoordinate: CLLocationCoordinate2D?
+    @StateObject private var keyboard = KeyboardResponder()
     private var currencyFormatter: NumberFormatter {
         let formatter = NumberFormatter()
         formatter.numberStyle = .currency
@@ -43,7 +44,8 @@ struct PostView: View {
                 .padding()
             } else {
                 NavigationStack {
-                    VStack (spacing: 16){
+                    ScrollView {
+                        VStack(spacing: 16) {
                         Text("New Listing")
                             .font(.title)
                             .bold()
@@ -106,11 +108,14 @@ struct PostView: View {
                         .cornerRadius(8)
                         
                         Spacer()
+                            .frame(height: 0)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.bottom, keyboard.keyboardHeight)
                     }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .applyThemeBackground()
-                    .tint(.purple)
-                    .toolbar {
+                .tint(.purple)
+                .toolbar {
                         ToolbarItem(placement: .navigationBarTrailing) {
                             Button("Cancel") {
                                 selection = previousSelection


### PR DESCRIPTION
## Summary
- add `KeyboardResponder` helper to track keyboard height
- use `KeyboardResponder` in `AddressSearchField` and `PostView`
- wrap post form in a `ScrollView` and pad content when the keyboard shows

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_685cd3558810832894e16f342864f0a0