### PR TITLE
Add update logic for tool creation

### DIFF
--- a/Starter/Starter/PostView.swift
+++ b/Starter/Starter/PostView.swift
@@ -139,18 +139,30 @@ struct PostView: View {
     
     /// Save the entered data to the server and return to the previous tab on success.
     private func savePost() {
+        guard let coordinate = selectedCoordinate else { return }
         fetchUsers { users in
             guard let match = users.first(where: { $0.username == username }) else {
                 return
             }
             let ownerId = match.id
             let createdAt = ISO8601DateFormatter().string(from: Date())
-            createTool(name: name, price: price, description: description, ownerId: ownerId, createdAt: createdAt, authToken: authToken) { success in
+            createTool(
+                name: name,
+                price: price,
+                description: description,
+                ownerId: ownerId,
+                createdAt: createdAt,
+                latitude: coordinate.latitude,
+                longitude: coordinate.longitude,
+                authToken: authToken
+            ) { success in
                 if success {
                     DispatchQueue.main.async {
                         name = ""
                         price = 0.0
                         description = ""
+                        address = ""
+                        selectedCoordinate = nil
                         selection = previousSelection
                     }
                 }

--- a/Starter/Starter/ToolDetailView.swift
+++ b/Starter/Starter/ToolDetailView.swift
@@ -50,5 +50,19 @@ struct ToolDetailView: View {
 }
 
 #Preview {
-    ToolDetailView(tool: Tool(id: 1, name: "Hammer", price: "$10", description: "A sturdy hammer.", owner_id: 1, owner_username: "johndoe", owner_email: "johndoe@example.com", owner_first_name: "John", owner_last_name: "Doe"))
+    ToolDetailView(
+        tool: Tool(
+            id: 1,
+            name: "Hammer",
+            price: "$10",
+            description: "A sturdy hammer.",
+            owner_id: 1,
+            owner_username: "johndoe",
+            owner_email: "johndoe@example.com",
+            owner_first_name: "John",
+            owner_last_name: "Doe",
+            latitude: 37.7749,
+            longitude: -122.4194
+        )
+    )
 }


### PR DESCRIPTION
## Summary
- extend `Tool` model with latitude and longitude
- add preview data for the new properties
- pass selected coordinates into `savePost`
- update `createTool` to include lat/long and perform PUT when the tool exists

## Testing
- `swift --version`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_685cd78394c08328977d9a687071ee92