### PR TITLE
Add lat/long support when posting tools

### DIFF
--- a/Starter/Starter/PostView.swift
+++ b/Starter/Starter/PostView.swift
@@ -145,7 +145,16 @@ struct PostView: View {
             }
             let ownerId = match.id
             let createdAt = ISO8601DateFormatter().string(from: Date())
-            createTool(name: name, price: price, description: description, ownerId: ownerId, createdAt: createdAt, authToken: authToken) { success in
+            createTool(
+                name: name,
+                price: price,
+                description: description,
+                ownerId: ownerId,
+                createdAt: createdAt,
+                authToken: authToken,
+                latitude: selectedCoordinate?.latitude,
+                longitude: selectedCoordinate?.longitude
+            ) { success in
                 if success {
                     DispatchQueue.main.async {
                         name = ""


### PR DESCRIPTION
## Summary
- extend `Tool` model with optional `latitude` and `longitude` properties
- overhaul `createTool` to update an existing record when a tool with the same name exists
- add helper `createNewTool` and `updateTool` functions
- pass the selected coordinate from `PostView` when saving a new listing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685cd78394c08328977d9a687071ee92