### PR TITLE
Add signup form and buttons

### DIFF
--- a/Starter/Starter/AccountView.swift
+++ b/Starter/Starter/AccountView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct AccountView: View {
     let username: String
     @Binding var showLogin: Bool
+    @Binding var showSignUp: Bool
     @AppStorage("authToken") private var authToken: String = ""
     @State private var user: User?
 
@@ -15,6 +16,11 @@ struct AccountView: View {
                     showLogin = true
                 }
                 .buttonStyle(.borderedProminent)
+                .tint(.purple)
+                Button("Sign Up") {
+                    showSignUp = true
+                }
+                .buttonStyle(.bordered)
                 .tint(.purple)
             }
             .padding()
@@ -121,5 +127,5 @@ struct AccountView: View {
 }
 
 #Preview {
-    AccountView(username: "daniel", showLogin: .constant(false))
+    AccountView(username: "daniel", showLogin: .constant(false), showSignUp: .constant(false))
 }

--- a/Starter/Starter/ChatView.swift
+++ b/Starter/Starter/ChatView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct ChatView: View {
     /// Controls presentation of the login sheet from the parent view.
     @Binding var showLogin: Bool
+    /// Controls presentation of the signup sheet from the parent view.
+    @Binding var showSignUp: Bool
     @AppStorage("authToken") private var authToken: String = ""
 
     var body: some View {
@@ -15,6 +17,11 @@ struct ChatView: View {
                         showLogin = true
                     }
                     .buttonStyle(.borderedProminent)
+                    .tint(.purple)
+                    Button("Sign Up") {
+                        showSignUp = true
+                    }
+                    .buttonStyle(.bordered)
                     .tint(.purple)
                 }
                 .padding()
@@ -29,5 +36,5 @@ struct ChatView: View {
 }
 
 #Preview {
-    ChatView(showLogin: .constant(false))
+    ChatView(showLogin: .constant(false), showSignUp: .constant(false))
 }

--- a/Starter/Starter/ContentView.swift
+++ b/Starter/Starter/ContentView.swift
@@ -6,11 +6,15 @@ import SwiftUI
 struct ContentView: View {
     @AppStorage("username") private var storedUsername: String = "Guest"
     @State private var showLogin = false
+    @State private var showSignUp = false
 
     var body: some View {
-        MainTabView(username: storedUsername, showLogin: $showLogin)
+        MainTabView(username: storedUsername, showLogin: $showLogin, showSignUp: $showSignUp)
             .sheet(isPresented: $showLogin) {
-                LoginView(showLogin: $showLogin)
+                LoginView(showLogin: $showLogin, showSignUp: $showSignUp)
+            }
+            .sheet(isPresented: $showSignUp) {
+                SignUpView(showSignUp: $showSignUp)
             }
     }
 }

--- a/Starter/Starter/ListingsView.swift
+++ b/Starter/Starter/ListingsView.swift
@@ -4,6 +4,8 @@ struct ListingsView: View {
     let username: String
     /// Controls presentation of the login sheet from the parent view.
     @Binding var showLogin: Bool
+    /// Controls presentation of the signup sheet from the parent view.
+    @Binding var showSignUp: Bool
     @AppStorage("authToken") private var authToken: String = ""
     @State private var user: User?
     @State private var tools: [Tool] = []
@@ -18,6 +20,11 @@ struct ListingsView: View {
                         showLogin = true
                     }
                     .buttonStyle(.borderedProminent)
+                    .tint(.purple)
+                    Button("Sign Up") {
+                        showSignUp = true
+                    }
+                    .buttonStyle(.bordered)
                     .tint(.purple)
                 }
                 .padding()
@@ -84,5 +91,5 @@ struct ListingsView: View {
 }
 
 #Preview {
-    ListingsView(username: "daniel", showLogin: .constant(false))
+    ListingsView(username: "daniel", showLogin: .constant(false), showSignUp: .constant(false))
 }

--- a/Starter/Starter/LoginView.swift
+++ b/Starter/Starter/LoginView.swift
@@ -4,6 +4,8 @@ import SwiftUI
 struct LoginView: View {
     /// Controls presentation from the parent view.
     @Binding var showLogin: Bool
+    /// Controls presentation of the signup sheet from the parent view.
+    @Binding var showSignUp: Bool
     @AppStorage("username") private var storedUsername: String = "Guest"
     @AppStorage("authToken") private var authToken: String = ""
     @State private var username: String = ""
@@ -53,6 +55,10 @@ struct LoginView: View {
                         .padding(.horizontal)
                 }
                 .tint(.blue)
+                Button("Sign Up") {
+                    showSignUp = true
+                }
+                .foregroundColor(.white)
                 Spacer()
             }
         }
@@ -63,5 +69,5 @@ struct LoginView: View {
 }
 
 #Preview {
-    LoginView(showLogin: .constant(true))
+    LoginView(showLogin: .constant(true), showSignUp: .constant(false))
 }

--- a/Starter/Starter/MainTabView.swift
+++ b/Starter/Starter/MainTabView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct MainTabView: View {
     let username: String
     @Binding var showLogin: Bool
+    @Binding var showSignUp: Bool
     @State private var selection = 0
     @State private var previousSelection = 0
     
@@ -14,25 +15,25 @@ struct MainTabView: View {
                 }
                 .tag(0)
             
-            ChatView(showLogin: $showLogin)
+            ChatView(showLogin: $showLogin, showSignUp: $showSignUp)
                 .tabItem {
                     Label("Chat", systemImage: "bubble.right")
                 }
                 .tag(1)
             
-            PostView(showLogin: $showLogin, selection: $selection, previousSelection: $previousSelection)
+            PostView(showLogin: $showLogin, showSignUp: $showSignUp, selection: $selection, previousSelection: $previousSelection)
                 .tabItem {
                     Label("Post", systemImage: "plus.app")
                 }
                 .tag(2)
             
-            ListingsView(username: username, showLogin: $showLogin)
+            ListingsView(username: username, showLogin: $showLogin, showSignUp: $showSignUp)
                 .tabItem {
                     Label("Listings", systemImage: "list.bullet")
                 }
                 .tag(3)
             
-            AccountView(username: username, showLogin: $showLogin)
+            AccountView(username: username, showLogin: $showLogin, showSignUp: $showSignUp)
                 .tabItem {
                     Label("Account", systemImage: "person")
                 }
@@ -47,5 +48,5 @@ struct MainTabView: View {
 }
 
 #Preview {
-    MainTabView(username: "daniel", showLogin: .constant(false))
+    MainTabView(username: "daniel", showLogin: .constant(false), showSignUp: .constant(false))
 }

--- a/Starter/Starter/Network.swift
+++ b/Starter/Starter/Network.swift
@@ -40,16 +40,31 @@ struct Tool: Codable, Identifiable {
     let owner_last_name: String?
 }
 
-func signup(username: String, password: String) {
-    guard let url = URL(string: "https://starter-ios-app-backend.onrender.com/signup") else { return }
+func signup(username: String, email: String, password: String, street: String, city: String, state: String, zip: String, phone: String, completion: @escaping (Bool) -> Void) {
+    guard let url = URL(string: "https://starter-ios-app-backend.onrender.com/signup") else { completion(false); return }
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
-    let body = ["username": username, "password": password]
+    let body: [String: Any] = [
+        "username": username,
+        "email": email,
+        "password": password,
+        "address": street,
+        "city": city,
+        "state": state,
+        "zip": zip,
+        "phone": phone
+    ]
     request.httpBody = try? JSONSerialization.data(withJSONObject: body)
 
-    URLSession.shared.dataTask(with: request).resume()
+    URLSession.shared.dataTask(with: request) { _, response, _ in
+        if let http = response as? HTTPURLResponse, http.statusCode == 201 {
+            completion(true)
+        } else {
+            completion(false)
+        }
+    }.resume()
 }
 
 func login(username: String, password: String, completion: @escaping (Bool) -> Void) {

--- a/Starter/Starter/PostView.swift
+++ b/Starter/Starter/PostView.swift
@@ -4,6 +4,8 @@ import MapKit
 struct PostView: View {
     /// Controls presentation of the login sheet from the parent view.
     @Binding var showLogin: Bool
+    /// Controls presentation of the signup sheet from the parent view.
+    @Binding var showSignUp: Bool
     /// Binding to the selected tab from `MainTabView` so the view can switch
     /// tabs when canceling or after saving a post.
     @Binding var selection: Int
@@ -38,6 +40,11 @@ struct PostView: View {
                         showLogin = true
                     }
                     .buttonStyle(.borderedProminent)
+                    .tint(.green)
+                    Button("Sign Up") {
+                        showSignUp = true
+                    }
+                    .buttonStyle(.bordered)
                     .tint(.green)
                 }
                 .padding()
@@ -160,5 +167,5 @@ struct PostView: View {
 }
 
 #Preview {
-    PostView(showLogin: .constant(false), selection: .constant(2), previousSelection: .constant(0))
+    PostView(showLogin: .constant(false), showSignUp: .constant(false), selection: .constant(2), previousSelection: .constant(0))
 }

--- a/Starter/Starter/SignUpView.swift
+++ b/Starter/Starter/SignUpView.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+/// Modal view that handles user signup.
+struct SignUpView: View {
+    /// Controls presentation from the parent view.
+    @Binding var showSignUp: Bool
+    @State private var username: String = ""
+    @State private var email: String = ""
+    @State private var password: String = ""
+    @State private var street: String = ""
+    @State private var city: String = ""
+    @State private var state: String = ""
+    @State private var zip: String = ""
+    @State private var phone: String = ""
+    @State private var showingAlert = false
+
+    var body: some View {
+        ZStack {
+            LinearGradient(
+                gradient: Gradient(colors: [Color.black.opacity(0.6), Color.blue.opacity(0.6)]),
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .ignoresSafeArea()
+            VStack(spacing: 16) {
+                Spacer()
+                Text("Sign Up")
+                    .font(.largeTitle)
+                    .bold()
+                    .foregroundColor(.white)
+                Group {
+                    TextField("Username", text: $username)
+                        .textInputAutocapitalization(.never)
+                        .autocapitalization(.none)
+                    TextField("Email", text: $email)
+                        .textInputAutocapitalization(.never)
+                        .autocapitalization(.none)
+                    SecureField("Password", text: $password)
+                    TextField("Street", text: $street)
+                    TextField("City", text: $city)
+                    TextField("State", text: $state)
+                    TextField("ZIP", text: $zip)
+                    TextField("Phone", text: $phone)
+                }
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .padding(.horizontal)
+                Button("Create Account") {
+                    signup(username: username, email: email, password: password, street: street, city: city, state: state, zip: zip, phone: phone) { success in
+                        DispatchQueue.main.async {
+                            if success {
+                                showSignUp = false
+                            } else {
+                                showingAlert = true
+                            }
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(Color.white.opacity(0.8))
+                .foregroundColor(.blue)
+                .cornerRadius(8)
+                .padding(.horizontal)
+                Spacer()
+            }
+        }
+        .alert("Signup failed", isPresented: $showingAlert) {
+            Button("OK", role: .cancel) {}
+        }
+    }
+}
+
+#Preview {
+    SignUpView(showSignUp: .constant(true))
+}


### PR DESCRIPTION
## Summary
- add Signup view for account creation
- allow Signup button from Login screen
- show Signup buttons in places that previously only showed Login
- pipe Signup state through tab views
- extend signup network call to send more fields

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_686b166d629c832890e2bb4c3bcc16bb