### PR TITLE
Add chat tab functionality

### DIFF
--- a/Starter/Starter/ChatDetailView.swift
+++ b/Starter/Starter/ChatDetailView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+struct ChatDetailView: View {
+    let chatID: Int
+    @EnvironmentObject var chatManager: ChatManager
+    @State private var messageText = ""
+
+    private var chat: Chat? {
+        chatManager.chat(with: chatID)
+    }
+
+    var body: some View {
+        VStack {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    ForEach(chat?.messages ?? []) { msg in
+                        HStack {
+                            if msg.senderId == chatManager.currentUser {
+                                Spacer()
+                                Text(msg.text)
+                                    .padding(8)
+                                    .background(Color.purple.opacity(0.7))
+                                    .cornerRadius(8)
+                                    .foregroundColor(.white)
+                            } else {
+                                Text(msg.text)
+                                    .padding(8)
+                                    .background(Color.black.opacity(0.4))
+                                    .cornerRadius(8)
+                                    .foregroundColor(.white)
+                                Spacer()
+                            }
+                        }
+                        .padding(4)
+                        .id(msg.id)
+                    }
+                }
+                .onChange(of: chat?.messages.count ?? 0) { _ in
+                    if let last = chat?.messages.last {
+                        proxy.scrollTo(last.id, anchor: .bottom)
+                    }
+                }
+            }
+            HStack {
+                TextField("Message", text: $messageText)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                Button("Send") {
+                    guard !messageText.trimmingCharacters(in: .whitespaces).isEmpty else { return }
+                    chatManager.send(messageText, to: chatID)
+                    messageText = ""
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.purple)
+            }
+            .padding()
+        }
+        .navigationTitle(chat?.otherUsername ?? "Chat")
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .applyThemeBackground()
+    }
+}

--- a/Starter/Starter/ChatManager.swift
+++ b/Starter/Starter/ChatManager.swift
@@ -1,0 +1,108 @@
+import Foundation
+import SwiftUI
+
+struct ChatMessage: Identifiable {
+    let id: Int
+    let senderId: Int
+    let text: String
+    let date: Date
+}
+
+struct Chat: Identifiable {
+    /// The `id` corresponds to the other user's identifier so we can uniquely
+    /// map conversations to a specific user.
+    let id: Int
+    let otherUserId: Int
+    var otherUsername: String
+    var messages: [ChatMessage] = []
+}
+
+/// Manages retrieving and sending chat messages.
+final class ChatManager: ObservableObject {
+    @Published var chats: [Chat] = []
+
+    private var currentUserId: Int?
+    private var userLookup: [Int: String] = [:]
+    private let dateFormatter = ISO8601DateFormatter()
+
+    /// Identifier of the authenticated user loaded via `loadChats`.
+    var currentUser: Int? { currentUserId }
+
+    /// Load all chats involving the provided username from the backend.
+    func loadChats(for username: String) {
+        fetchUsers { [weak self] users in
+            guard let self = self,
+                  let me = users.first(where: { $0.username == username }) else { return }
+            self.currentUserId = me.id
+            self.userLookup = Dictionary(uniqueKeysWithValues: users.map { ($0.id, $0.username) })
+
+            fetchChats { rawMessages in
+                var grouped: [Int: Chat] = [:]
+                let relevant = rawMessages.filter { $0.sender_id == me.id || $0.recipient_id == me.id }
+
+                for raw in relevant {
+                    let otherId = raw.sender_id == me.id ? raw.recipient_id : raw.sender_id
+                    var chat = grouped[otherId] ?? Chat(id: otherId,
+                                                       otherUserId: otherId,
+                                                       otherUsername: self.userLookup[otherId] ?? "User",
+                                                       messages: [])
+                    let message = ChatMessage(
+                        id: raw.id,
+                        senderId: raw.sender_id,
+                        text: raw.message,
+                        date: self.dateFormatter.date(from: raw.created_at) ?? Date())
+                    chat.messages.append(message)
+                    grouped[otherId] = chat
+                }
+
+                let sorted = grouped.values.sorted {
+                    ($0.messages.last?.date ?? .distantPast) > ($1.messages.last?.date ?? .distantPast)
+                }
+
+                DispatchQueue.main.async {
+                    self.chats = sorted
+                }
+            }
+        }
+    }
+
+    /// Ensure a chat exists with the specified user id and username.
+    func startChat(with otherUserId: Int, username: String) -> Chat {
+        if let existing = chats.first(where: { $0.otherUserId == otherUserId }) {
+            return existing
+        }
+        let chat = Chat(id: otherUserId, otherUserId: otherUserId, otherUsername: username, messages: [])
+        chats.append(chat)
+        return chat
+    }
+
+    /// Send a message to the given user and append it locally if successful.
+    func send(_ text: String, to otherUserId: Int) {
+        guard let myId = currentUserId else { return }
+        let token = UserDefaults.standard.string(forKey: "authToken") ?? ""
+        createChatMessage(senderId: myId, recipientId: otherUserId, message: text, authToken: token) { [weak self] created in
+            guard let self = self, let created = created else { return }
+            let message = ChatMessage(
+                id: created.id,
+                senderId: created.sender_id,
+                text: created.message,
+                date: self.dateFormatter.date(from: created.created_at) ?? Date())
+            DispatchQueue.main.async {
+                if let index = self.chats.firstIndex(where: { $0.otherUserId == otherUserId }) {
+                    self.chats[index].messages.append(message)
+                } else {
+                    let chat = Chat(id: otherUserId,
+                                    otherUserId: otherUserId,
+                                    otherUsername: self.userLookup[otherUserId] ?? "User",
+                                    messages: [message])
+                    self.chats.append(chat)
+                }
+            }
+        }
+    }
+
+    /// Retrieve chat by the other user's identifier.
+    func chat(with otherUserId: Int) -> Chat? {
+        chats.first { $0.otherUserId == otherUserId }
+    }
+}

--- a/Starter/Starter/ChatView.swift
+++ b/Starter/Starter/ChatView.swift
@@ -4,6 +4,8 @@ struct ChatView: View {
     /// Controls presentation of the login sheet from the parent view.
     @Binding var showLogin: Bool
     @AppStorage("authToken") private var authToken: String = ""
+    @AppStorage("username") private var username: String = "Guest"
+    @EnvironmentObject var chatManager: ChatManager
 
     var body: some View {
         ZStack {
@@ -19,15 +21,27 @@ struct ChatView: View {
                 }
                 .padding()
             } else {
-                Text("Chat")
-                    .font(.largeTitle)
+                NavigationStack {
+                    List(chatManager.chats) { chat in
+                        NavigationLink(destination: ChatDetailView(chatID: chat.id)) {
+                            Text(chat.otherUsername)
+                        }
+                        .listRowBackground(Color.clear)
+                    }
+                    .listStyle(.plain)
+                    .scrollContentBackground(.hidden)
+                    .background(Color.clear)
+                    .navigationTitle("Chats")
+                }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .applyThemeBackground()
+        .task { chatManager.loadChats(for: username) }
     }
 }
 
 #Preview {
     ChatView(showLogin: .constant(false))
+        .environmentObject(ChatManager())
 }

--- a/Starter/Starter/ContentView.swift
+++ b/Starter/Starter/ContentView.swift
@@ -6,9 +6,11 @@ import SwiftUI
 struct ContentView: View {
     @AppStorage("username") private var storedUsername: String = "Guest"
     @State private var showLogin = false
+    @StateObject private var chatManager = ChatManager()
 
     var body: some View {
         MainTabView(username: storedUsername, showLogin: $showLogin)
+            .environmentObject(chatManager)
             .sheet(isPresented: $showLogin) {
                 LoginView(showLogin: $showLogin)
             }

--- a/Starter/Starter/ToolDetailView.swift
+++ b/Starter/Starter/ToolDetailView.swift
@@ -3,6 +3,9 @@ import SwiftUI
 struct ToolDetailView: View {
     let tool: Tool
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject var chatManager: ChatManager
+    @State private var showChat = false
+    @State private var startedChatID: Int?
 
     var body: some View {
         ScrollView {
@@ -19,10 +22,31 @@ struct ToolDetailView: View {
                 MapView()
                     .frame(height: 200)
                     .cornerRadius(20)
+
+                Button(action: {
+                    let chat = chatManager.startChat(with: tool.owner_id ?? 0, username: tool.owner_username ?? "User")
+                    startedChatID = chat.id
+                    showChat = true
+                }) {
+                    Text("Start Chat")
+                        .padding(8)
+                        .frame(maxWidth: .infinity)
+                }
+                .font(.title2)
+                .background(Color.black.opacity(0.4))
+                .shadow(radius: 8)
+                .cornerRadius(8)
+                .foregroundColor(.white)
+                .padding(.top, 8)
+
                 Spacer()
             }
             .padding()
         }
+        .background(
+            NavigationLink(destination: ChatDetailView(chatID: startedChatID ?? 0), isActive: $showChat) { EmptyView() }
+                .hidden()
+        )
         .applyThemeBackground()
         .navigationBarBackButtonHidden(true)
         .toolbar {
@@ -51,4 +75,5 @@ struct ToolDetailView: View {
 
 #Preview {
     ToolDetailView(tool: Tool(id: 1, name: "Hammer", price: "$10", description: "A sturdy hammer.", owner_id: 1, owner_username: "johndoe", owner_email: "johndoe@example.com", owner_first_name: "John", owner_last_name: "Doe"))
+        .environmentObject(ChatManager())
 }


### PR DESCRIPTION
## Summary
- introduce `ChatManager` to store chats and messages
- implement chat conversation UI in `ChatDetailView`
- show existing chats in `ChatView`
- add Start Chat button in `ToolDetailView`
- provide `ChatManager` via `ContentView`
- integrate chat features with backend API

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_686b16e9c3488328a12a3a678655af7a