### PR TITLE
Improve login/signup style

### DIFF
--- a/Starter/Starter/LoginView.swift
+++ b/Starter/Starter/LoginView.swift
@@ -15,52 +15,81 @@ struct LoginView: View {
     var body: some View {
         ZStack {
             LinearGradient(
-                gradient: Gradient(colors: [Color.black.opacity(0.6), Color.blue.opacity(0.6)]),
+                gradient: Gradient(colors: [Color.red, Color.orange]),
                 startPoint: .top,
                 endPoint: .bottom
             )
             .ignoresSafeArea()
-            VStack(spacing: 20) {
+
+            VStack(spacing: 24) {
                 Spacer()
-                Text("Log In")
-                    .font(.largeTitle)
-                    .bold()
-                    .foregroundColor(.white)
-                TextField("Username", text: $username)
-                    .textInputAutocapitalization(.never)
-                    .autocapitalization(.none)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                    .padding(.horizontal)
-                    .dismissKeyboardOnSwipeDown()
-                SecureField("Password", text: $password)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                    .padding(.horizontal)
-                    .dismissKeyboardOnSwipeDown()
-                Button(action: {
-                    login(username: username, password: password) { success in
-                        DispatchQueue.main.async {
-                            if success {
-                                storedUsername = username
-                                showLogin = false
-                            } else {
-                                showingAlert = true
-                            }
-                        }
-                    }
-                }) {
+
+                VStack(spacing: 24) {
                     Text("Log In")
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                        .background(Color.white.opacity(0.8))
-                        .foregroundColor(.blue)
-                        .cornerRadius(8)
-                        .padding(.horizontal)
+                        .font(.title)
+                        .fontWeight(.semibold)
+                        .foregroundColor(.white)
+
+                    VStack(spacing: 16) {
+                        TextField("Username", text: $username)
+                            .textInputAutocapitalization(.never)
+                            .autocapitalization(.none)
+                            .padding()
+                            .background(
+                                RoundedRectangle(cornerRadius: 12)
+                                    .fill(Color.white.opacity(0.1))
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: 12)
+                                            .stroke(Color.white.opacity(0.2), lineWidth: 1)
+                                    )
+                            )
+                            .foregroundColor(.white)
+                            .dismissKeyboardOnSwipeDown()
+
+                        SecureField("Password", text: $password)
+                            .padding()
+                            .background(
+                                RoundedRectangle(cornerRadius: 12)
+                                    .fill(Color.white.opacity(0.1))
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: 12)
+                                            .stroke(Color.white.opacity(0.2), lineWidth: 1)
+                                    )
+                            )
+                            .foregroundColor(.white)
+                            .dismissKeyboardOnSwipeDown()
+
+                        Button(action: {
+                            login(username: username, password: password) { success in
+                                DispatchQueue.main.async {
+                                    if success {
+                                        storedUsername = username
+                                        showLogin = false
+                                    } else {
+                                        showingAlert = true
+                                    }
+                                }
+                            }
+                        }) {
+                            Text("Log In")
+                        }
+                        .buttonStyle(PrimaryButtonStyle())
+
+                        Button("Sign Up") {
+                            showSignUp = true
+                        }
+                        .buttonStyle(SecondaryButtonStyle())
+                    }
                 }
-                .tint(.blue)
-                Button("Sign Up") {
-                    showSignUp = true
-                }
-                .foregroundColor(.white)
+                .padding(.horizontal, 32)
+                .padding(.vertical, 40)
+                .background(
+                    RoundedRectangle(cornerRadius: 20)
+                        .fill(Color.black.opacity(0.6))
+                        .shadow(color: Color.black.opacity(0.3), radius: 20, x: 0, y: 10)
+                )
+                .padding(.horizontal, 24)
+
                 Spacer()
             }
         }

--- a/Starter/Starter/SignUpView.swift
+++ b/Starter/Starter/SignUpView.swift
@@ -19,61 +19,90 @@ struct SignUpView: View {
     var body: some View {
         ZStack {
             LinearGradient(
-                gradient: Gradient(colors: [Color.black.opacity(0.6), Color.blue.opacity(0.6)]),
+                gradient: Gradient(colors: [Color.red, Color.orange]),
                 startPoint: .top,
                 endPoint: .bottom
             )
             .ignoresSafeArea()
-            VStack(spacing: 16) {
-                Spacer()
-                Text("Sign Up")
-                    .font(.largeTitle)
-                    .bold()
-                    .foregroundColor(.white)
-                Group {
-                    TextField("Username", text: $username)
-                        .textInputAutocapitalization(.never)
-                        .autocapitalization(.none)
-                    TextField("Email", text: $email)
-                        .textInputAutocapitalization(.never)
-                        .autocapitalization(.none)
-                    SecureField("Password", text: $password)
-                    TextField("Street", text: $street)
-                    TextField("City", text: $city)
-                    TextField("State", text: $state)
-                    TextField("ZIP", text: $zip)
-                    TextField("Phone", text: $phone)
-                }
-                .textFieldStyle(RoundedBorderTextFieldStyle())
-                .padding(.horizontal)
-                .dismissKeyboardOnSwipeDown()
-                Button("Create Account") {
-                    signup(username: username, email: email, password: password, street: street, city: city, state: state, zip: zip, phone: phone) { success in
-                        DispatchQueue.main.async {
-                            if success {
-                                login(username: username, password: password) { loggedIn in
-                                    DispatchQueue.main.async {
-                                        if loggedIn {
-                                            showSignUp = false
-                                            showLogin = false
-                                        } else {
-                                            showingAlert = true
+
+            ScrollView {
+                VStack(spacing: 24) {
+                    Spacer(minLength: 0)
+
+                    VStack(spacing: 24) {
+                        Text("Sign Up")
+                            .font(.title)
+                            .fontWeight(.semibold)
+                            .foregroundColor(.white)
+
+                        Group {
+                            TextField("Username", text: $username)
+                                .textInputAutocapitalization(.never)
+                                .autocapitalization(.none)
+                            TextField("Email", text: $email)
+                                .textInputAutocapitalization(.never)
+                                .autocapitalization(.none)
+                            SecureField("Password", text: $password)
+                            TextField("Street", text: $street)
+                            TextField("City", text: $city)
+                            TextField("State", text: $state)
+                            TextField("ZIP", text: $zip)
+                            TextField("Phone", text: $phone)
+                        }
+                        .padding()
+                        .background(
+                            RoundedRectangle(cornerRadius: 12)
+                                .fill(Color.white.opacity(0.1))
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 12)
+                                        .stroke(Color.white.opacity(0.2), lineWidth: 1)
+                                )
+                        )
+                        .foregroundColor(.white)
+                        .dismissKeyboardOnSwipeDown()
+
+                        Button("Create Account") {
+                            signup(
+                                username: username,
+                                email: email,
+                                password: password,
+                                street: street,
+                                city: city,
+                                state: state,
+                                zip: zip,
+                                phone: phone
+                            ) { success in
+                                DispatchQueue.main.async {
+                                    if success {
+                                        login(username: username, password: password) { loggedIn in
+                                            DispatchQueue.main.async {
+                                                if loggedIn {
+                                                    showSignUp = false
+                                                    showLogin = false
+                                                } else {
+                                                    showingAlert = true
+                                                }
+                                            }
                                         }
+                                    } else {
+                                        showingAlert = true
                                     }
                                 }
-                            } else {
-                                showingAlert = true
                             }
                         }
+                        .buttonStyle(PrimaryButtonStyle())
                     }
+                    .padding(.horizontal, 32)
+                    .padding(.vertical, 40)
+                    .background(
+                        RoundedRectangle(cornerRadius: 20)
+                            .fill(Color.black.opacity(0.6))
+                            .shadow(color: Color.black.opacity(0.3), radius: 20, x: 0, y: 10)
+                    )
+                    .padding(.horizontal, 24)
+
+                    Spacer(minLength: 0)
                 }
-                .frame(maxWidth: .infinity)
-                .padding()
-                .background(Color.white.opacity(0.8))
-                .foregroundColor(.blue)
-                .cornerRadius(8)
-                .padding(.horizontal)
-                Spacer()
             }
         }
         .alert("Signup failed", isPresented: $showingAlert) {


### PR DESCRIPTION
## Summary
- update `LoginView` and `SignUpView` to match the gradient theme
- use custom button styles and rounded card layouts for a cleaner look

## Testing
- `swift test` *(fails: no Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_6878262c82508328a9da9488c6f9b717